### PR TITLE
Add image urls

### DIFF
--- a/ArcanaOfTheAncientsBestiary.json
+++ b/ArcanaOfTheAncientsBestiary.json
@@ -9514,7 +9514,7 @@
     {
       "name": "Varakith",
       "source": "AotA",
-      "page": 0,
+      "page": 240,
       "size": "L",
       "type": "monstrosity",
       "alignment": [
@@ -9621,12 +9621,12 @@
             "type": "image",
             "href": {
               "type": "external",
-              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_144_Image_0002.png"
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_242_Image_0002.png"
             }
           }
         ]
       },
-      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_144_Image_0002.png"
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_242_Image_0002.png"
     },
     {
       "name": "Xi-Drake",

--- a/ArcanaOfTheAncientsBestiary.json
+++ b/ArcanaOfTheAncientsBestiary.json
@@ -1,10110 +1,10831 @@
 {
-	"_meta": {
-		"sources": [
-			{
-				"json": "AotA",
-				"abbreviation": "AotA",
-				"full": "Arcana of the Ancients",
-				"color": "6441A4",
-				"version": "",
-				"url": "https://www.montecookgames.com/store/product/arcana-of-the-ancients/",
-				"authors": [
-					"Sean K. Reynolds",
-					"Bruce R. Cordell",
-					"Monte Cook"
-				],
-				"convertedBy": [
-					"attanaz"
-				]
-			}
-		],
-		"dateAdded": 1591117986,
-		"dateLastModified": 1591117986
-	},
-	"monster": [
-		{
-			"name": "Accelerator",
-			"source": "AotA",
-			"page": 142,
-			"size": "H",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 19,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 195,
-				"formula": "17d12 + 85"
-			},
-			"speed": {
-				"walk": 60,
-				"fly": {
-					"number": 10,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 22,
-			"dex": 12,
-			"con": 20,
-			"int": 16,
-			"wis": 16,
-			"cha": 14,
-			"save": {
-				"con": "+9",
-				"int": "+7",
-				"wis": "+7",
-				"cha": "+6"
-			},
-			"skill": {
-				"perception": "+7"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 17,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"several ancient languages",
-				"can learn a new language in minutes"
-			],
-			"cr": "10",
-			"trait": [
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The accelerator's attacks are treated as if magical."
-					]
-				},
-				{
-					"name": "Paranoid and Fearful",
-					"entries": [
-						"It is very difficult to gain an accelerator's trust. Creatures have disadvantage on attempts to convince it that they aren't a threat. If successful, they only make it indifferent and wary for a few minutes, or perhaps an hour at most."
-					]
-				},
-				{
-					"name": "Modification (Recharges after a Short or Long Rest)",
-					"entries": [
-						"About one in four accelerators have found a way to install a device within its shell that gives it an additional ability as a bonus action.",
-						"Typically these devices are one of the following: a force field that adds +2 AC for one minute, a rocket pack that lets it move up to 500 feet, or a mental scrambler that gives all living creatures within 60 feet disadvantage on all rolls their next round."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The accelerator makes three claw attacks and uses its control velocity ability."
-					]
-				},
-				{
-					"name": "Claw",
-					"entries": [
-						"{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}19 ({@damage 3d8 + 6}) slashing damage."
-					]
-				},
-				{
-					"name": "Control Velocity",
-					"entries": [
-						"The accelerator can change the speed and direction of up to three objects and creatures within 10 feet, such as halting a moving creature or causing a still object to suddenly move rapidly in any direction. Typically it uses this to hurl a light object (up to 50 pounds), hurl a heavy object (up to 100 pounds), hurl a foe (up to 300 pounds), or stop a moving creature or object (up to 300 pounds)."
-					]
-				},
-				{
-					"name": "Hurl Light Object",
-					"entries": [
-						"{@atk rw} {@hit 7} to hit, range",
-						"150/600 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Hurl Heavy Object",
-					"entries": [
-						"{@atk rw} {@hit 7} to hit, range",
-						"30/60 ft., one target. {@h}12 ({@damage 2d8 + 3}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Hurl Foe",
-					"entries": [
-						"The target must succeed on a {@dc 15} Strength or Dexterity saving throw (target's choice) or be thrown up to 60 feet away, taking 12 ({@damage 2d8 + 3}) bludgeoning damage from impacting the ground or a solid obstacle."
-					]
-				},
-				{
-					"name": "Stop Movement",
-					"entries": [
-						"The target must succeed on a {@dc 15} Strength or Dexterity saving throw (target's choice) or be {@condition grappled} and {@condition restrained} in its current space for one round."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"S"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"RW"
-			],
-			"conditionInflict": [
-				"grappled",
-				"restrained"
-			],
-			"tokenUrl":"",
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"An accelerator is an artificial intelligence encased in a metal shell with numerous limbs, sensory devices, and other accoutrements that allow it to interact with and understand the world around itself. An accelerator fears “death” (perhaps “dissolution” is a better term) and concocts elaborate plans to develop better protections for itself. Ironically, sometimes this puts it in danger as it tries to take control of a defensible fortress or obtain a device that will grant it a powerful defense. A fully upright accelerator stands 15 feet high. Paranoia. Accelerators aren’t evil, but their interest in putting their own existence ahead of others means they might act in ways that people consider villainous. If seriously threatened, an accelerator always chooses flight over fight.",
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "It is fascinating that such a large and powerful creature would be so fearful of death that its entire existence is a desperate obsession with survival. It makes me wonder what horrors it survived ages ago that led it to where it is now—perhaps its kind are the last survivors of a great cataclysm, war, or divine retribution."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "I’m just glad they’re not interested in conquest. If they were aggressive like chromatic dragons or fire giants . . . with their knowledge and skills, they could attack a town and leave nothing but corpses."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							},
-							{
-							"type":"entries",
-							"name":"Paranoia",
-							"entries":[
-								"Accelerators aren’t evil, but their interest in putting their own existence ahead of others means they might act in ways that people consider villainous. If seriously threatened, an accelerator always chooses flight over fight."
-								]
-							},
-							{
-							"type":"entries",
-							"name":"Salvage",
-							"entries":[
-								"A destroyed ccelerator can be salvaged for up to 1d6 + 1 cyphers and one oddity"
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Aliopter",
-			"source": "AotA",
-			"page": 144,
-			"size": "L",
-			"type": "aberration",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 142,
-				"formula": "15d10 + 60"
-			},
-			"speed": {
-				"walk": 30,
-				"fly": {
-					"number": 100,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 16,
-			"dex": 14,
-			"con": 18,
-			"int": 2,
-			"wis": 12,
-			"cha": 5,
-			"save": {
-				"str": "+6",
-				"con": "+7"
-			},
-			"skill": {
-				"perception": "+4",
-				"stealth": "+5"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 14,
-			"resist": [
-				"bludgeoning"
-			],
-			"conditionImmune": [
-				"charmed",
-				"prone"
-			],
-			"languages": [
-				""
-			],
-			"cr": "8",
-			"trait": [
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The aliopter's attacks are treated as if magical."
-					]
-				},
-				{
-					"name": "Reactive Tongues",
-					"entries": [
-						"An aliopter has four reactions that can be used only for opportunity attacks."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The aliopter makes four barbed tongue attacks."
-					]
-				},
-				{
-					"name": "Barbed Tongue",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d10 + 3}) slashing damage. If the target is a Medium or smaller creature, it must succeed on a {@dc 15} Strength or Dexterity saving throw or be {@condition grappled} and {@condition restrained} (escape {@dc 15}). If the target is a living creature, it also must succeed on a {@dc 16} Constitution saving throw or be infected with a disease\u2014a cluster of aliopter larvae.",
-						"The aliopter larvae live and grow beneath the target's flesh for about a week, after which they move to the creature's tongue and cause it to swell. Eventually the victim's throat becomes blocked by the swollen tongue and they begin to choke; every 10 minutes they must succeed on a {@dc 16} Constitution saving throw or start suffocating. After six hours of this, the tongue ruptures, and tiny aliopters squirm out.",
-						"If the target is dead, the young alioptors feed on the corpse before joining together into a single mass and begin searching for new prey.",
-						"The aliopter's reproductive process holds true for most humanoid creatures. It might take a different form in another creature, such as growing in the target's stomach or lungs before bursting out and eating the dead host.",
-						"If the disease is cured before the larvae's emergence, the unborn aliopters are disintegrated."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"S"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"grappled",
-				"restrained"
-			],
-			"tokenUrl":"",
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"An aliopter looks like a horrific cloud ofwrithing, undulating tongues. It is a colony of many organisms fused together into one composite creature weighing several hundred pounds. It sweeps out of the cover of shadows to attack prey, flying by some unknown means of negating gravity in a precisely controlled manner. They seem to originate from ancient ruins, particularly those with a connection to another world orbiting a far-off star.",
-							{
-							"type":"entries",
-							"name":"Hunger and Reproduction.",
-							"entries":[
-								"An aliopter’sonly motive is to feed and reproduce. It is a near-mindless predator that cannot be reasoned with. Once it has successfully injected its larvae into a victim, it focuses on feeding for the next few months and no longer attempts to implant anything."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Anhedon",
-			"source": "AotA",
-			"page": 145,
-			"size": "M",
-			"type": "monstrosity",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 90,
-				"formula": "12d8 + 36"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 16,
-			"dex": 10,
-			"con": 16,
-			"int": 14,
-			"wis": 13,
-			"cha": 11,
-			"save": {
-				"str": "+5",
-				"con": "+5"
-			},
-			"skill": {
-				"arcana": "+4"
-			},
-			"passive": 13,
-			"resist": [
-				"bludgeoning"
-			],
-			"languages": [
-				"Anhedon and usually two or three others"
-			],
-			"cr": "4",
-			"trait": [
-				{
-					"name": "Red Eyes",
-					"entries": [
-						"An anhedon cannot see in darkness, but its eyes emit red light that allows it to see up to 60 feet as if it were bright light."
-					]
-				},
-				{
-					"name": "Safe Falling",
-					"entries": [
-						"Because it subconsciously manipulates gravity to land safely, an anhedon never takes falling damage."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Crushing Gravity",
-					"entries": [
-						"An anhedon can increase gravity on a",
-						"Medium or smaller target within 60 feet. The target must make a {@dc 15} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone}, {@condition restrained}, and take 13 ({@damage 3d6 + 3}) bludgeoning damage. On a successful save, the target takes only half damage and isn't knocked {@condition prone} or {@condition restrained}. A {@condition restrained} target can attempt a save every round to escape this force, otherwise it takes damage again and continues to be held {@condition prone} and {@condition restrained}. The anhedon can only restrain one creature at a time with this ability."
-					]
-				},
-				{
-					"name": "Cancel or Reverse Gravity",
-					"entries": [
-						"An anhedon can cancel gravity for a target within 60 feet, making it float around like a feather on the wind until it can escape, or reverse gravity completely on the target for one round, causing it to fall up to 100 feet up and then down again, taking {@damage 1d6} bludgeoning damage per 10 feet fallen. A creature can resist the gravity effect with a successful {@dc 13} Strength or Dexterity saving throw (target's choice) to grab onto a fixed object within reach to prevent itself from falling up."
-					]
-				},
-				{
-					"name": "Deadly Leap",
-					"entries": [
-						"An anhedon can decrease and increase gravity on itself as it jumps so that it smashes to the ground up to 100 feet away from its starting point. All creatures within 10 feet of where it lands it must succeed on a {@dc 13} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 13 ({@damage 3d6 + 3}) bludgeoning damage. On a successful save, the creature takes only half damage and isn't knocked {@condition prone}."
-					]
-				}
-			],
-			"damageTags": [
-				"B"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"prone",
-				"restrained"
-			],
-			"tokenUrl":"",
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"Dour and severe, anhedons are humanoid-shaped creatures protected with a carapace of dark stone breached only by twin beams of red light for eyes. It is possible that this carapace is actually some kind of stone armor powered by geological forces.",
-							{
-							"type":"entries",
-							"name":"Obsessed Searcher",
-							"entries":[
-								"Anhedons are searching for something they call the Meeting of All Things—a thing they will name but never describe. They negotiate with those who seem like they could help with this goal, but woe to those who lie about knowing where to find what the anhedons seek. They are otherwise hateful creatures that would rather kill other beings than negotiate with."
-								]
-							},
-							{
-							"type":"entries",
-							"name":"Mysterious Origin.",
-							"entries":[
-								"Origin. Anhedons seem to simply (and literally) fall out of the sky and start working on finding information about the Meeting of All Things. They don’t seem to have families or young, or at least not on this world, and they don’t have lairs, only remaining in one place as long as necessary to exhaust all avenues of inquiry relevant to that location."
-								]
-							},
-							{
-							"type":"entries",
-							"name":"Salvage",
-							"entries":[
-								"Anhedon carapace or armor can be be salvaged for a couple of cyphers and two to three oddities"
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Arric Frog",
-			"source": "AotA",
-			"page": 146,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-				"U"
-			],
-				"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 120,
-				"formula": "16d10 + 12"
-			},
-				"speed": {
-				"walk": 50,
-				"swim": 30
-			},
-			"str": 15,
-			"dex": 13,
-			"con": 15,
-			"int": 2,
-			"wis": 10,
-			"cha": 3,
-			"save": {
-				"str": "+5",
-				"con": "+6"
-			},
-			"skill": {
-				"athletics": "+5",
-				"perception": "+3"
-			},
-
-				"senses": [
-					"darkvision 60 ft."
-				],
-				"passive": 13,
-				"cr": "5",
-				"trait": [
-				{
-					"name": "Amphibious",
-					"entries": [
-						"The arric frog can breathe air and water."
-					]
-				},
-				{
-					"name": "Standing Leap",
-					"entries": [
-						"The arric frog's long jump is up to 20 feet and its high jump is up to 10 feet, with or without a running start."
-					]
-				}
-			],
-				"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}29 ({@damage 6d8 + 2}) piercing damage. If the target is a Medium or smaller creature, it must succeed on a {@dc 13} Strength saving throw or be knocked {@condition prone}."
-					]
-				},
-				{
-					"name": "Swallow",
-					"entries": [
-						"The frog uses its sticky tongue against a Small or smaller creature or metallic object (such as a cypher) within 5 feet. The target must succeed on a {@dc 13} Strength or Dexterity saving throw; failure means the frog yanks the creature or object away and swallows it. The swallowed target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the frog, and it takes 10 ({@damage 3d6}) acid damage at the start of each of the frog's turns. The frog can have up to two targets swallowed at a time.",
-						"If the frog dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse using 5 feet of movement, exiting {@condition prone}."
-					]
-				},
-				{
-					"name": "Spit Cyst {@recharge}",
-					"entries": [
-						"The frog can spit a biomechanical cyst at a location within 60 feet, which explodes in a 5-foot-radius sphere, dealing 14 ({@damage 4d6}) damage, or half that if the target succeeds on a {@dc 13} Dexterity saving throw. The cyst's damage is fire, lightning, or piercing (equal chances for each sphere)."
-					]
-				}
-			],
-			"traitTags": [
-				"Amphibious"
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Swallow"
-			],
-			"damageTags": [
-				"A",
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			"conditionInflict": [
-				"blinded",
-				"prone",
-				"restrained"
-			],
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"Arric frogs are wide-bodied amphibians with lumpy flesh, cold eyes, and metallic teeth. They hunt living prey in the deeps and shallows and on the coast, and they scavenge for small pieces of metal they can swallow.",
-							{
-							"type":"entries",
-							"name":"Spawning Cysts",
-							"entries":[
-								"As they grow and age, arric frogs develop egg-like biomechanical cysts within their bodies, adjacent to the stomach. Eventually these cysts erupt into the stomach, the beast vomits one forth, and the cyst sheds its outer layer of protective skin to reveal an {@footnote arric sphere with mechanical and fleshy parts|Use stats for type two basic automaton, with fly 30 ft.|Basic automaton, page 246}, which then flies off. Sometimes this process fails and the arric frog retains these cysts for years, which become quite painful. Eventually the tortured creature drags itself out of the water in search of relief, attacks anything it can reach, and dies, at which point the cysts finally erupt and the newborn arric spheres can finally scatter."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Beast Mounts",
-								"entries":[
-									"An arric frog can be trained as a mount and ridden with a wide saddle. The rider may use a special goad that encourages the frog to eject an explosive cyst."
-									]
-								},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"A slain Arric Frog might have one or two biomechanical cysts inside its body, which can be harvested for cyphers."
-									]
-								}
-							]
-						}
-					]
-				}
-		},
-		{
-			"name": "Astraphin Monolith",
-			"source": "AotA",
-			"page": 147,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 19,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 102,
-				"formula": "12d8 + 48"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 0,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 18,
-			"dex": 6,
-			"con": 18,
-			"int": 3,
-			"wis": 10,
-			"cha": 3,
-			"save": {
-				"str": "+7",
-				"con": "+7"
-			},
-			"skill": {
-				"perception": "+2"
-			},
-			"senses": [
-				"darkvision 120 ft.",
-				"tremorsense 120 ft."
-			],
-			"passive": 13,
-			"resist": [
-				"bludgeoning",
-				"poison"
-			],
-			"immune": [
-				"necrotic",
-				"poisoned"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned",
-				"stunned"
-			],
-			"cr": "8",
-			"trait": [
-				{
-					"name": "Plant Mind",
-					"entries": [
-						"The floating monolith is a construction of the astraphin plant growing on the ground all around it, often stretching for hundreds of feet in all directions. Even a small portion of the plant is enough to control the monolith, so unless the characters are able to completely destroy all plant life in the area, attacking or controlling plants won't end the threat of the monolith. The monolith itself is not a plant and is therefore immune to effects that only work on plants."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The astraphin monolith uses two eye blasts."
-					]
-				},
-				{
-					"name": "Eye Blast",
-					"entries": [
-						"The monolith shoots energy out of its eye, choosing one of the following effects:",
-						"Force Blast: A creature within 200 feet must make a {@dc 15} Dexterity saving throw, taking 36 ({@damage 8d8}) force damage on a failed save, or half as much damage on a successful one.",
-						"Psychic Blast: A creature within 200 feet must make a {@dc 15} Intelligence saving throw, taking 27 ({@damage 6d8}) psychic damage on a failed save, or half as much damage on a successful one.",
-						"Paralysis Blast: A creature within 200 feet must succeed on a",
-						"{@dc 15} Constitution saving throw or be {@condition paralyzed}. The target can attempt another saving throw every round at the end of their turn to free themselves from this effect.",
-						"Heat Wave: This sweeping ray of heat affects creatures within 10 feet, which take 7 ({@damage 2d6}) fire damage."
-					]
-				}
-			],
-			"senseTags": [
-				"SD",
-				"T"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"F",
-				"O",
-				"Y"
-			],
-			"tokenUrl":"",
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"An astraphin monolith is a floating, immobile obelisk of stone standing a bit taller than a human, with a single crystalline eye. The eye can create dangerous blasts at long range, leading some to believe it is a hostile earth elemental creature. However, the stone is neither living nor sentient, but rather the extension of a concealed intelligece.",
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "I once made the mistake of thinking this creature was some kind of stone elemental. The monolith ignored our druid friend’s attempts to speak with it, and instead used its psychic blasts to turn his brain into jelly."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Yet another reason I hate plant monsters."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							},
-							{
-							"type":"entries",
-							"name":"Hidden Plant",
-							"entries":[
-								"Originally, astraphin was a type of  sometimes fertilized its poor mountain soil by trapping and killing small creatures. In ages past, an unknown energy infused the astraphin, causing it to mutate and develop new abilities, including a simple intelligence. Now it can  and vines, making subtle changes in th a stone monolith over weeks or months. A fully formed monolith springs from the ground to float 10 to 15 feet (3 to 4.6 m) in the air. The plant controls this monolith, using it to kill larger prey and feeding on the corpses through its extensive root system. Destroying the monolith doesn’t harm the plant (it’s equivalent to trimming a fingernail), but it is a setback that takes the plant a while to remedy."]
-							},
-							{
-								"type":"entries",
-								"name":"Immovable Destroyer",
-								"entries":[
-									"An astraphin monolith does not move from its position. It can rotate in place, but apparently doesn’t have the ability to move laterally (or perhaps it can only move very slowly, a matter of inches per day). Because the monolith can’t pursue its opponents, running away is a viable survival strategy, although its incredible range often allows it to dispatch fleeing prey. Some greedy explorers choose to fight a monolith in the hopes of claiming its valuable crystal eye."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Monolith Eye",
-								"entries":[
-									"The astraphin monolith’s crystalline eye is prized because it can be used as a weapon or a power source for a depleted relic. If used as a weapon, it fires a blast of force at one creature within 200 feet. On a failed DC 15 Dexterity saving throw, the target takes 5d8 force damage. The eye has a depletion of 1–3 in 1d100 when used this way.",
-									"A character can attach the eye to a depleted relic by spending one hour and making a DC 15 Intelligence (Arcana) check. If successful, the relic functions again and has a depletion of 1 in 1d6; failure means the character makes a depletion roll for the eye (1 in 1d6, checked each attempt). Once connected to a relic, if the relic depletes again, so does the monolith eye."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"In addition to looting a slain monolith’s eye as treasure, the area around it usually has several decaying creatures in the soil, which might have carried cyphers (typically 1d3 cyphers are found)."
-									]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Beastcoat Infiltrator",
-			"source": "AotA",
-			"page": 149,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-				"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 71,
-				"formula": "11d8 + 22"
-			},
-			"speed": {
-				"walk": 60,
-				"climb": 30,
-				"swim": {
-					"number": 40,
-					"condition": "(as appropriate for its current disguise)"
-				}
-			},
-			"str": 16,
-			"dex": 14,
-			"con": 14,
-			"int": 8,
-			"wis": 12,
-			"cha": 10,
-			"skill": {
-				"athletics": "+5",
-				"deception": "+2",
-				"perception": "+3",
-				"stealth": "+3",
-				"survival": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "4",
-			"trait": [
-				{
-					"name": "Keen Hearing and Smell",
-					"entries": [
-						"The beastcoat infiltrator has advantage on Wisdom (Perception) checks that rely on hearing or smell."
-					]
-				},
-				{
-					"name": "Limited Beast Disguise",
-					"entries": [
-						"A beastcoat infiltrator can alter its external shape by telescoping its limbs and expanding the plates on its outer surface, but at best this is only a rough approximation. Even when covered in grown animal flesh, it looks more like an animatronic puppet than a real creature, which is usually sufficient to fool other animals. It can vary its size category from a Small to a Medium creature, but this does not affect its stats, and it doesn't assume a radically larger or smaller size that a typical specimen of what it's imitating (it wouldn't become a Small seskii or a Medium ravage bear)."
-					]
-				}
-			],"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The beastcoat infiltrator makes two or three attacks, typically bites and claws, as appropriate for the animal it is emulating. If encountered without a disguise, or if it thinks it will be destroyed, it may use an electrical stun attack in place of one of its melee attacks."
-					]
-				},
-				{
-					"name": "Bite or Claw",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@dice 1d8 + 3}) piercing or slashing."
-					]
-				},
-				{
-					"name": "Electrical Stun",
-					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 30 ft., one target. {@h}7 ({@damage 2d6}) lightning damage plus the target must succeed on a {@dc 13} Constitution saving throw or fall {@condition unconscious} for one minute."
-					]
-				}
-			],
-			"traitTags": [
-				"Keen Senses"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"L"
-			],
-			"miscTags": [
-				"MW",
-				"RW"
-			],
-			"conditionInflict": [
-				"unconscious"
-			],
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"Many automatons were built to wage war, for mundane tasks, or for unknowable purposes, but it seems that some were made to understand other things. Examples of the latter are beastcoat infiltrators—adaptive machines that study common animals, learn their behavior, reshape themselves to match their subjects, and cover themselves with harvested or grown flesh (including fur, feathers, or scales) to infiltrate the creatures they are studying.",
-							{
-								"type":"entries",
-								"name":"Just Another Animal",
-								"entries":[
-									"Beastcoat infiltrators adapt to the social structure of a type of animal or beast (such as deer, tigers, or even ravage bears) and become part of the group. They have been seen aiding a hunt, bringing food back to the lair, helping to raise animal offspring, and otherwise contributing to the welfare of the group while continuing their observations. After weeks, months, or years, the infiltrator leaves to repeat the process with a different group of animals."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Maintaining the Role",
-								"entries":[
-									"Beastcoat infiltrators either quietly track and observe animals or pretend to be a particular kind of animal, making sure its behavior does not confuse or alarm the living animals it associates with. A character who can communicate with machines might coax it into a limited communication."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"An infiltrator can be salvaged for a couple of cyphers or perhaps a relic. Instead of a relic, PCs may be able to loot its data core, which, if they are able to access the information within it, can be used as a book about animal biology."
-									]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Blood Barm",
-			"source": "AotA",
-			"page": 150,
-			"size": "S",
-			"type": "beast",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 33,
-				"formula": "6d6 + 12"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 14,
-			"dex": 15,
-			"con": 14,
-			"int": 7,
-			"wis": 12,
-			"cha": 8,
-			"skill": {
-				"perception": "+3",
-				"stealth": "+4",
-				"survival": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Martial Advantage",
-					"entries": [
-						"Once per turn, the blood barm can deal an extra 7 ({@damage 2d6}) damage to a creature it hits with an attack if that creature is within 5 feet of another blood barm that isn't {@condition incapacitated}."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Spew Explosive Blood Bubble",
-					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 15/30 ft., one creature. {@h}9 ({@damage 2d6 + 2}) piercing damage. The target must succeed on a {@dc 12} Constitution saving throw or a seed from one of the blood bubbles is implanted in a target's skin for 1 minute, during which time the target suffers 1 point of damage per round. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
-					]
-				},
-				{
-					"name": "Blood Sac Birth {@recharge}",
-					"entries": [
-						"Barms can break their own body sacs by pressing them against a PC or an object. The larger sacs burst first due to their extended size, and any young barms (1-4) within are born. Treat each youngling as a tiny blood barm with 31 hit points that lacks this ability."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"RW"
-			],
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"Its long neck craning this way and that, the four-footed blood barm doesn’t have an easily distinguishable head or eyes. Instead, a barm has a large opening at the end of its neck covered with a clear membrane similar to an eyelid. The creature’s body, somewhat turkey-shaped, is covered with myriad vesicles rather than feathers, ranging in color from dark green to gray to crimson. These bubbles are filled with liquid and hard seeds. Some seeds have “sprouted,” and these sacs swell with tiny, unborn barms. When the young are close to hatching, the sacs can grow half as large as the barm itself.",
-							{
-								"type":"entries",
-								"name":"Defensive Flocking.",
-								"entries":[
-									"Blood barms often move about in flocks of two to four. They are not aggressive unless their young are threatened. However, if a flock of barms and their young are located in or near a site the PCs need to access, they might attack."
-									]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Bowg",
-			"source": "AotA",
-			"page": 151,
-			"size": "M",
-			"type": "monstrosity",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 11,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 65,
-				"formula": "10d8 + 20"
-			},
-			"speed": {
-				"walk": 30,
-				"climb": 30
-			},
-			"str": 13,
-			"dex": 12,
-			"con": 16,
-			"int": 6,
-			"wis": 10,
-			"cha": 8,
-			"skill": {
-				"arcana": "+0 (+2 for mind linked Bowgs)",
-				"perception": "+2"
-			},
-			"senses": [
-				"darkvision 30 ft."
-			],
-			"passive": 12,
-			"cr": "1/4",
-			"trait": [
-				{
-					"name": "Built to Serve",
-					"entries": [
-						"A bowg has disadvantage on saving throws to resist psychic or machine attempts to control their minds."
-					]
-				},
-				{
-					"name": "Mindlinked Advantage",
-					"entries": [
-						"Once mental or machine contact or control with a bowg is established, the bowg's Intelligence increases to 9 for the duration of the contact and for approximately 10 minutes thereafter. This gives it a +2 bonus on attack rolls, Intelligence checks, and Intelligence saving throws."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"A wild bowg makes two attacks, usually two claws or a claw and a bite. A mindlinked bowg uses weapons like greatclubs and shortbows, and may be equipped with a cypher by its master."
-					]
-				},
-				{
-					"name": "Bite or Claw",
-					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing or slashing damage."
-					]
-				},
-				{
-					"name": "Greatclub",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d8 + 1}) bludgeoning damage. (This includes the mindlinked bowg's +2 bonus on attack rolls.)"
-					]
-				},
-				{
-					"name": "Shortbow",
-					"entries": [
-						"{@atk rw} {@hit 5} to hit, range 80/320 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage. (This includes the mindlinked bowg's +2 bonus on attack rolls.)"
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"MW",
-				"RNG",
-				"RW"
-			],
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"These two-legged pseudoprimates have prominent teeth, four arms (two organic, two metallic), and large mechanical sockets on their backs.",
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "If my clan had ever spied one of these creeping around the Delve back in the day, we would have left no tunnel unfired to burn them out."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							},
-							{
-								"type":"entries",
-								"name":"Wild Bowgs.",
-								"entries":[
-									"A typical bowg has the intelligence of a smart animal, such as an ape. They use animalistic tactics and are likely to flee if outmatched. They avoid unknown creatures unless they are very hungry or sense the presence of a mind- or machine-talker—it is not uncommon for wild bowgs to follow a humanoid with these abilities at a distance, subconsciously hoping for the contact that will make them smarter."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Mindlinked Bowgs.",
-								"entries":[
-									"A bowg’s sockets make them receptive to commands from intelligent machines and psychic entities, turning them into compliant servants for entities that lack the ability to manipulate objects directly. Bowgs thrive on and seek out this contact,as it improves their own ability to think, deduce, and plan, making them almost on par with a typical human. These bowgs use manufactured weapons and better battle tactics (especially if their master gives them instructions about what to do in combat). Mindlinked bowgs are loyal to their master if well-treated (which may make them friendly or hostile toward explorers), but are not willing to harm themselves or others of their kind."
-									]
-							},
-							{
-								"type":"inset",
-								"entries":[
-									"In addition to psychic creatures and machines with the ability to talk to other machines, bowgs are similarly receptive to mental contact from numenera (such as an eye of mental contact) andcharm spells, as well as machine-based contacts (such as from a mask of machine speaking)."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage.",
-								"entries":[
-									"The undamaged sockets of a pack of several bowgs might be salvaged for a couple of cyphers. Mindlinked bowgs also may carry conventional equipment and cyphers."
-									]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Callerail",
-			"source": "AotA",
-			"page": 152,
-			"size": "H",
-			"type": "monstrosity",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 180,
-				"formula": "19d12 + 57"
-			},
-			"speed": {
-				"walk": 40
-			},
-			"str": 21,
-			"dex": 14,
-			"con": 16,
-			"int": 7,
-			"wis": 15,
-			"cha": 18,
-			"save": {
-				"dex": "+7",
-				"con": "+9",
-				"wis": "+7",
-				"cha": "+9"
-			},
-			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
-			],
-			"passive": 12,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"poisoned"
-			],
-			"cr": "14",
-			"trait": [
-				{
-					"name": "Absorbing Form",
-					"entries": [
-						"A creature that touches the callerail takes 4 ({@damage 1d8}) acid damage, as matter is transferred from the object to the callerail; the callerail regains 4 ({@dice 1d8}) hit points."
-					]
-				},
-				{
-					"name": "Legendary Resistance (1/Day)",
-					"entries": [
-						"If the callerail fails a saving throw, it can choose to succeed instead."
-					]
-				},
-				{
-					"name": "Monstrosity's Sight",
-					"entries": [
-						"Magical darkness doesn't impede the callerail's darkvision."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The callerail has advantage on saving throws against spells and other magical effects."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The callerail makes three attacks: one with its bite, and two with bludgeoning limbs to make slam attacks."
-					]
-				},
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d6 + 5}) piercing damage plus 10 ({@damage 3d6}) acid damage.",
-						"In addition, the callerail regains 10 ({@dice 3d6}) hit points."
-					]
-				},
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d4 + 5}) bludgeoning damage plus 10 ({@damage 3d6}) acid damage. In addition, the callerail regains 10 ({@dice 3d6}) hit points. o receive a foe's attack, and the attack automatically hits.",
-						"The attacking foe must succeed on a {@dc 17} Dexterity saving throw or their weapon is absorbed into the callerail. Whether the saving throw is successful (and the weapon is retained) or not, the attack fails to inflict damage on the callerail. If a nonmagical weapon is absorbed, the callerail regains 10 ({@dice 3d6}) hit points, and the weapon is destroyed. If a magical weapon is absorbed, it becomes part of the callerail; to retrieve it, the callerail must be destroyed.",
-						"The callerail could choose to regain hit points simply by absorbing portions of what's around it, and absorb a 5-foot- cube of nonmagical wood, stone, or metal (or helpless flesh, whether alive or dead). When it does, it regains 10 ({@dice 3d6}) hit points."
-					]
-				}
-			],
-			"legendary": [
-				{
-					"name": "Attack",
-					"entries": [
-						"The callerail makes one slam attack."
-					]
-				},
-				{
-					"name": "Move",
-					"entries": [
-						"The callerail moves up to half its speed."
-					]
-				},
-				{
-					"name": "Seize (Costs 2 Actions)",
-					"entries": [
-						"The callerail makes one Object Absorption attack."
-					]
-				}
-			],
-			"traitTags": [
-				"Legendary Resistances",
-				"Magic Resistance"
-			],
-			"senseTags": [
-				"B",
-				"SD"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"A",
-				"B",
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-							"A callerail is a creature of fused organic and inorganic substances. Flesh mingles with wood, steel, and stone, as the callerail possesses the ability to absorb inorganic matter and add the material to its body. The creature is a lumbering giant—15 feet tall—that walks using its forelimbs as well as its shorter rear legs. Its body is a conglomeration of materials.",
-							"A callerail’s organic portions remain cohesive so that its circulatory system reaches all areas of its body. It still requires food—in fact, it requires even more food than an ordinary creature of its size.",
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "If you took a demonic ape, gave it the appetite of a bulette, and added in a rust monster’s hunger for metal, that would be a reasonable approximation of a callerail. We are very lucky that they are solitary and aggressive toward their own kind."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "If we’re just making stuff up, I say like the tarrasque had a baby with an iron golem and was raised by a tribe of orc barbarians."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							},
-							{
-								"type":"entries",
-								"name":"Unreasoning Monstrosity.",
-								"entries":[
-									"Unreasoning Monstrosity. Reasoning with a hungry callerail is impossible, and they’re always hungry. However, a smart character can fool them by setting a trap, creating a diversion, or using a similar type of tactic. They are not particularly bright and act on animal instinct in most situations."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Focused on Dominance.",
-								"entries":[
-									"Callerails move into an area and threaten the entire region. Two callerails in the same locale pose a danger to every living thing. The monsters fight to the death, each attempting to absorb the inorganic portions of the other and destroying everything that gets in their way. Afterward, the victor reproduces asexually."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Chirog",
-			"source": "AotA",
-			"page": 154,
-			"size": "M",
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"chirog"
-				]
-			},
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 16,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 90,
-				"formula": "12d8 + 36"
-			},
-			"speed": {
-				"walk": 30,
-				"climb": 30
-			},
-			"str": 16,
-			"dex": 12,
-			"con": 16,
-			"int": 10,
-			"wis": 8,
-			"cha": 8,
-			"skill": {
-				"arcana": "+2",
-				"perception": "+2"
-			},
-			"passive": 11,
-			"languages": [
-				"Chirog",
-				"Common"
-			],
-			"cr": "4",
-			"trait": [
-				{
-					"name": "Sure-Footed",
-					"entries": [
-						"The chirog has advantage on Strength and Dexterity saving throws made against effects that would knock it {@condition prone}."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}17 ({@damage 4d6 + 3}) piercing damage."
-					]
-				},
-				{
-					"name": "Grapple",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one Medium or smaller creature. {@h}The creature is {@condition grappled} (escape {@dc 13}). Until this grapple ends, the target is {@condition grappled} and {@condition restrained}, and the chirog can't grapple or bite another target."
-					]
-				}
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"grappled",
-				"restrained"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Chirogs are vaguely reptilian humanoids with thick armor plates covering much of their body. They live to hunt and kill, but despite their savage nature, they are craftier and more intelligent than most savage humanoids. They {@footnote understand the numenera||Optional Rule: Intelligence (Ancients Arcana), page 259} and despise it. Even more than killing, they enjoy destroying devices of the ancient past. (Perhaps it is racial resentment for {@footnote wrongs done to them long ago|Chirogs might be mutant offshoots of what are now kobolds, lizardfolk, or even dragonkin.}.) Chirogs are hateful and angry, but not impossible to reason with. They speak their own simple language, and about one in three can speak or understand another language (typically Common or one used nearby). Chirogs do not use weapons or tools.",
-							{
-								"type":"entries",
-								"name":"Corrupt Families",
-								"entries":[
-									"Each chirog pack has a clear leader who is usually a female, and is likely the mother of many members of the pack. The creatures have a tangled, incestuous relationship, and mature females eventually leave to form a new pack, sometimes taking a brother or two with them."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Among the Trees and Rocks",
-								"entries":[
-									"Chirogs live in small groups of three to six, usually in wooded areas or rocky, mountainous regions. Because they are adept at climbing, they often build nests or hovels in high branches or on cliff faces where other creatures cannot easily see or reach them."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Cragworm",
-			"source": "AotA",
-			"page": 155,
-			"size": "G",
-			"type": "monstrosity",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 201,
-				"formula": "13d20 + 65"
-			},
-			"speed": {
-				"walk": 50
-			},
-			"str": 20,
-			"dex": 10,
-			"con": 21,
-			"int": 2,
-			"wis": 8,
-			"cha": 4,
-			"save": {
-				"con": "+9",
-				"wis": "+3"
-			},
-			"senses": [
-				"blindsight 30 ft.",
-				"tremorsense 60 ft."
-			],
-			"passive": 13,
-			"cr": "9",
-			"trait": [
-				{
-					"name": "Easily Deceived",
-					"entries": [
-						"A cragworm is particularly easy to fool if food is involved. They have been known to chase after a fleeing horse and ignore a group of travelers that remain very still until it leaves the area. Cragworms have disadvantage on Intelligence checks to recognize a deception when easily- acquired food is available."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The cragworm's attacks are treated as if magical."
-					]
-				},
-				{
-					"name": "Stone Camouflage",
-					"entries": [
-						"A cragworm has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}19 ({@damage 4d6 + 5}) piercing damage, and the target must make a {@dc 17} Constitution saving throw, taking 35 ({@damage 10d6}) poison damage on a failed save, or half as much damage on a successful one. If the target is a Large or smaller creature, it must succeed on a {@dc 17} Dexterity saving throw or be swallowed by the cragworm. A swallowed creature is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the worm, and it takes 10 ({@damage 3d6}) acid damage at the start of each of the cragworm's turns.",
-						"If the cragworm takes 20 damage or more on a single turn from a creature inside it, the cragworm must succeed on a {@dc 17} Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall {@condition prone} in a space within 10 feet of the cragworm. If the cragworm dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 20 feet of movement, exiting {@condition prone}."
-					]
-				},
-				{
-					"name": "Howl {@recharge 5}",
-					"entries": [
-						"Before it emerges to attack, the cragworm howls, reverberating in the audible and subsonic ranges. Each creature within 120 feet of the cragworm must make a {@dc 17} Constitution save. Success means the creature is {@condition paralyzed} for one round, or two rounds for a failed save."
-					]
-				}
-			],
-			"actionTags": [
-				"Swallow"
-			],
-			"damageTags": [
-				"A",
-				"I",
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"MW",
-				"RCH"
-			],
-			"conditionInflict": [
-				"blinded",
-				"paralyzed",
-				"restrained"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			      	"A cragworm is a spiny serpent-like creature that can grow up to 50 feet long. It dwells in abandoned or isolated areas, preying on whatever it can find, and eating plants only when starving.",
-							{
-								"type":"entries",
-								"name":"Feeding Its Hunger",
-								"entries":[
-									"A cragworm has the intelligence of an animal and the outlook of a predator. It can’t be reasoned with, but if confronted before it attacks with a sufficient threat or distraction, it can be intimidated or tricked into leaving a group of creatures alone in favor of easier targets. Once it starts fighting, it only stops if it is killed or there is no prey within sight."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Strange Anatomy",
-								"entries":[
-									"A cragworm’s mouth opens horizontally, and it has many rows of teeth to help it trap and swallow prey. It has many red, glistening eyes, usually arranged in clusters along the length of its body, but the ones that aren’t near its head are only good for spotting movement, and it will turn its head to bring its best eyes to bear on its prey."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Crith",
-			"source": "AotA",
-			"page": 156,
-			"size": "S",
-			"type": "aberration",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 49,
-				"formula": "9d6 + 18"
-			},
-			"speed": {
-				"walk": 30,
-				"climb": 15,
-				"swim": 15
-			},
-			"str": 12,
-			"dex": 12,
-			"con": 14,
-			"int": 2,
-			"wis": 8,
-			"cha": 6,
-			"save": {
-				"con": "+4"
-			},
-			"senses": [
-				"darkvision 30 ft."
-			],
-			"passive": 9,
-			"resist": [
-				"bludgeoning"
-			],
-			"immune": [
-				"necrotic",
-				"poison"
-			],
-			"conditionImmune": [
-				"poisoned",
-				"prone"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Absorb Nutrients",
-					"entries": [
-						"A crith feeds by absorbing nutrients through its host's skin. A creature hosting a crith starts each day with one fewer Hit Die than normal. (For example, a",
-						"3rd-level fighter with a crith only has two {@dice d10}s they can spend to recover hit points from resting each day.) A creature that normally only has 1 Hit Die will die in its sleep within a day of becoming a crith's host."
-					]
-				},
-				{
-					"name": "Bonded Gift",
-					"entries": [
-						"A crith's host is immune to poison damage and diseases."
-					]
-				},
-				{
-					"name": "Immune to Disease",
-					"entries": [
-						"A crith is immune to diseases."
-					]
-				},
-				{
-					"name": "Nightmares",
-					"entries": [
-						"The crith's bond with its host causes terrible nightmares of strange places and creatures. Although this isn't enough to prevent the character from gaining the benefit of rest, the host is {@condition frightened} for one hour after waking (the source of its fear is internal and doesn't have to be within line of sight). These nightmares even affect hosts that meditate in a trance instead of sleeping."
-					]
-				},
-				{
-					"name": "Strong Bond",
-					"entries": [
-						"Once bonded, a crith doesn't want to let go, and it sinks tiny barbs into its host's flesh to maintain its grip. To tear off a bonded crith, the host (or someone helping them) must make a {@dc 17} Strength saving throw. Each failed attempt deals 7 ({@damage 2d6}) slashing damage to the host, and a successful attempt deals 14 ({@damage 4d6}) slashing damage to the host, and removes it.",
-						"These actions do not harm the crith, which is likely to attack whatever is trying to remove it from its host."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Tendrils",
-					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}8 ({@damage 2d6 + 1}) slashing damage and the target must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} for one round."
-					]
-				},
-				{
-					"name": "Parasitic Bond",
-					"entries": [
-						"The crith bonds to a helpless or willing creature it can touch. It can only bond to one creature at a time."
-					]
-				},
-				{
-					"name": "Poison Spray {@recharge}",
-					"entries": [
-						"The crith releases a fine mist in a 10-foot-radius sphere. All creatures in the sphere must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} for one round.",
-						"Because this depletes its ability to poison with its tendrils until the ability recharges, a crith normally only uses this ability to escape when it otherwise would be killed."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"S"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			"conditionInflict": [
-				"paralyzed"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A crith is a lump of ebony, fleshy material about 2 feet in diameter when inactive. However, it can roughly mimic the shape of any creature it touches, though only in miniature. Other times, it moves by forming legs or arms as needed to run or climb.",
-							{
-								"type":"entries",
-								"name":"Parasitic",
-								"entries":[
-									"Criths feed by skin-to-skin contact, absorbing nutrients directly. When a crith finds a {@footnote victim|A Large creature might be host to two or more criths.}, it adheres itself to the creature, taking on the appearance of a child-sized silhouette of the larger victim, which it attempts to embrace. In return for nutrition from this embrace, a crith provides certain advantages, but the bond also gives the host bizarre {@footnote nightmares|Sometimes the nightmares that crith hosts endure show locations that actually exist, or at least used to. Likewise with the strange creatures these nightmares sometimes include.}. For most creatures, the nightmares become bad enough that they decide to remove the crith, which is a painful task."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Cuiddit",
-			"source": "AotA",
-			"page": 157,
-			"size": "T",
-			"type": "construct",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				17
-			],
-			"hp": {
-				"average": 54,
-				"formula": "12d4 + 24"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"swim": 30,
-				"canHover": true
-			},
-			"str": 3,
-			"dex": 14,
-			"con": 14,
-			"int": 13,
-			"wis": 14,
-			"cha": 8,
-			"save": {
-				"dex": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned",
-				"prone"
-			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Obvious",
-					"entries": [
-						"A cuiddit's constant noise and flashing lights means it always fails Stealth checks. Any of its companions within 10 feet have disadvantage on Stealth checks."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Force Fields",
-					"entries": [
-						"Although it doesn't have limbs, a cuiddit can extend two translucent fields of force from itself to manipulate objects within 5 feet. These force fields use the cuiddit's Strength and Dexterity scores. It can also combine these two limbs to create a force field barrier (up to a 10-foot square) or simple solid objects of force that could fit within a 10-foot cube, such as a table, ladder, or ramp. It might use a barrier to prevent a foe of its companions from entering a room, or block an escape route for its own companions."
-					]
-				},
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 2}) bludgeoning damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"B"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A cuiddit is a levitating sphere, not quite as large as a human head, made of crystal and some hard opaque substance. Images in light play across the surface—sometimes images of a face (though never the same one twice), other times of random, odd scenes or objects. Sounds also constantly trickle from the cuiddit—tinkling or booming, cacophonous or melodic, familiar or utterly alien. Usually found completely inert, it might be mistaken for an oddity or useless junk until it suddenly awakens and—once some form of communication is established—seems determined to offer its aid.",
-							{
-								"type":"entries",
-								"name":"Limited Communication",
-								"entries":[
-									"A cuiddit doesn’t speak any known language, but it seems to react to communication by changing its images and sounds in response to questions and statements. Even telepathic communication gives these enigmatic responses that are subject to the speaker’s interpretation. Sometimes explorers feel like they are beginning to understand a cuiddit’s reactions by interpreting them depending on the context, but whether they really do understand or are just fooling themselves is up for debate."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Erratic Helper",
-								"entries":[
-									"When a cuiddit notices other creatures, it begins to follow them around until it is destroyed or driven away. At first, those being followed might appreciate the aid a cuiddit provides. But eventually, they may grow tired of the light show and incessant sounds. Eventually a cuiddit betrays its companions, but it is unknown whether this is a deliberate and malicious act, a misunderstood response to its companion’s actions, or simply erratic programming. This betrayal might be as simple as pushing a character off a ledge, attracting the attention of a nearby monster, or blocking a path of escape."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The remains of a cuiddit can be salvaged for one or two cyphers."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Culova",
-			"source": "AotA",
-			"page": 158,
-			"size": "M",
-			"type": "monstrosity",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 38,
-				"formula": "7d8 + 5"
-			},
-			"speed": {
-				"walk": 30,
-				"climb": 30
-			},
-			"str": 15,
-			"dex": 15,
-			"con": 12,
-			"int": 10,
-			"wis": 13,
-			"cha": 13,
-			"skill": {
-				"climb": "+5",
-				"perception": "+3"
-			},
-			"passive": 13,
-			"languages": [
-				"Culova",
-				"a few know Common"
-			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Ambusher",
-					"entries": [
-						"The culova has advantage on attack rolls against any creature it has surprised."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Spiked Club",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}13 ({@damage 3d6 + 2} piercing damage."
-					]
-				},
-				{
-					"name": "Javelin",
-					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 30/120 ft., one target. {@h}13 ({@damage 3d6 + 2} piercing damage."
-					]
-				},
-				{
-					"name": "Poison Spray {@recharge}",
-					"entries": [
-						"The culova sprays venom from its mouth, turning its head almost 360 degrees, affecting up to eight targets within 10 feet. Each creature affected must make a {@dc 13} Dexterity saving throw, taking 7 ({@damage 2d6}) poison damage on a failed save, or half as much damage on a successful one.",
-						"Other culovas are immune to this venom."
-					]
-				}
-			],
-			"traitTags": [
-				"Ambusher"
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"I"
-			],
-			"miscTags": [
-				"MW",
-				"RW",
-				"THW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Culovas are {@spidery humanoids|Culovas might be a mutant offshoot of a creature like an ettercap, or ettercaps might be near- humanoid mutations of ancient culovas.} with eight spindly legs, a bulbous midsection, and a pair of human-like arms with three fingers. Eight eyes adorn their heads like colored beads above disturbingly broad, toothy mouths. They move with astonishing quickness.",
-							{
-								"type":"entries",
-								"name":"Forest Hunters",
-								"entries":[
-									"Although they look monstrous, culovas are usually peaceful creatures that live in small groups deep within a forest, hunting for food and caring for their young. They lead simple lives and have little interest in building large structures. Unlike most spidery creatures, culovas do not make webs."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Territorial",
-								"entries":[
-									"Culovas avoid contact with other intelligent creatures unless they or their territories are threatened. They repel groups of intelligent creatures (such as marauding humanoids or people who want to log their forests) with weapons and their venom."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Elusive",
-								"entries":[
-									"Culovas do not leave familiar ground except in extraordinary circumstances, so they are always on the defensive, even when they launch an attack. However, an attacking culova can be reasoned with. If they can be convinced that an intruder is not a threat or that they’ll cease being a threat—which usually involves leaving the area—they might be willing to let their opponents leave peacefully."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"Very rarely, a culova might have a cypher. They never have other treasure or things that a human might find valuable."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Cynoclept",
-			"source": "AotA",
-			"page": 159,
-			"size": "L",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 127,
-				"formula": "15d10 + 45"
-			},
-			"speed": {
-				"walk": 30,
-				"climb": 30
-			},
-			"str": 16,
-			"dex": 12,
-			"con": 16,
-			"int": 8,
-			"wis": 8,
-			"cha": 8,
-			"skill": {
-				"arcana": "+3",
-				"perception": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"resist": [
-				"fire",
-				"lightning"
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "9",
-			"trait": [
-				{
-					"name": "Cypher Sense",
-					"entries": [
-						"A cynoclept automatically senses the presence of all cyphers within 60 feet unless the cyphers are behind a force field."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The cynoclept's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The cynoclept makes two limb attacks and uses its activate cypher ability. If a limb hits, the cynoclept can use steal and repair against the same target."
-					]
-				},
-				{
-					"name": "Limb",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d8 + 3}) bludgeoning, piercing, or slashing damage."
-					]
-				},
-				{
-					"name": "Activate Cypher",
-					"entries": [
-						"As a bonus action, a cynoclept can activate a cypher within 10 feet (whether held by another creature or merely in the area) as if it were holding the cypher. If the cypher is in the possession of another creature, that creature can resist this attempt with a successful {@dc 13} Intelligence saving throw."
-					]
-				},
-				{
-					"name": "Steal and Repair",
-					"entries": [
-						"An injured cynoclept can grab a cypher and add the device to its own body, repairing 30 points of damage.",
-						"If this takes it over its normal hit point total, it gains the excess amount as temporary hit points. If the targeted cypher is in the possession of another creature, that creature can resist this grab attempt with a successful {@dc 13} Strength or Dexterity saving throw."
-					]
-				},
-				{
-					"name": "Psychic Trap",
-					"entries": [
-						"Approximately 10% of cynoclepts are made of amber crystal that is psionically reactive to the mental energy of most humanoids. For these cynoclepts, if their attempt to activate an opponent's cypher succeeds, the opponent's mind temporarily becomes trapped in the cynoclept's body for one minute and its body falls {@condition unconscious}. The only Intelligence saving throw each round on their turn, with a success returning the passenger to their own body. Killing the cynoclept  automatically returns a trapped passenger's mind to their own body."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A thick outer shell of amber crystal protects the cynoclept, so it has little to fear. The shell grows as the creature accumulates cyphers and other special numenera components. Initially not much larger than a human’s fist, it eventually grows to be 6 feet in diameter, at which time it begins to openly roam locations where cyphers might be found, or if the opportunity arises, it follows explorers who’ve recently looted cyphers from a location it was watching.",
-							{
-								"type": "insetReadaloud",
-								"entries": [
-									{
-										"type":"quote",
-										"entries":[
-											"Remember when that tiefling wizard thought he tamed one of these things? He even rode around on it like a giant turtle and fed it little cyphers as treats."
-										],
-										"by":"Faim Trubeard, dwarf veteran and prospector"
-									}
-								]
-							},
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Yes, and I remember the day he used a mind-augmenting cypher that grafted itself to his head, and the cynoclept decapitated him and ran off with it—the cypher, with his head still attached."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-								"type":"entries",
-								"name":"Negotiable Manace",
-								"entries":[
-									"Cynoclepts are clever, and though they don’t speak a language, they can be negotiated with through pictures drawn on the ground, pantomime, or sign language. They are motivated by finding more cyphers or salvaged amber crystal."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Cannibal",
-								"entries":[
-									"Although a cynoclept’s primary diet is cyphers, when they meet others of their kind (including the rarely-seen smaller, younger forms), they attempt to eat and absorb their fellows, giving and receiving no quarter."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The wreck of a cynoclept’s body can be salvaged for about six cyphers."
-								]
-							},
-							{
-								"type":"inset",
-								"entries":[
-									"When characters exceed their cypher limit, cynoclepts can spontaneously form from the interaction, robbing the character of their belongings and creating a dangerous threat in the same instant."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Cypherid",
-			"source": "AotA",
-			"page": 161,
-			"size": "S",
-			"type": "construct",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 27,
-				"formula": "6d6 + 6"
-			},
-			"speed": {
-				"walk": 30,
-				"climb": 10
-			},
-			"str": 13,
-			"dex": 14,
-			"con": 13,
-			"int": 3,
-			"wis": 8,
-			"cha": 5,
-			"skill": {
-				"perception": "+1"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 11,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Cypher Sense",
-					"entries": [
-						"A cypherid automatically senses the presence of all cyphers within 60 feet unless the cyphers are behind a force field."
-					]
-				},
-				{
-					"name": "Swarm Targeting",
-					"entries": [
-						"If four or more cypherids attack the same target, each cypherid gains advantage on its attack roll, and their opponents have disadvantage on saving throws against the incorporated cypher ability."
-					]
-				},
-				{
-					"name": "Numenera Camouflage",
-					"entries": [
-						"The cypherid has advantage on Dexterity (Stealth) checks made to hide in numenera ruins and amist other pieces of the numenera, including scrap."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The cypherid makes one attack with its blade. If that attack hits, the cypherid can use steal and repair against the same target."
-					]
-				},
-				{
-					"name": "Blade",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 1}) piercing or slashing damage. If the target has any cyphers, the cypherid can use its steal and repair ability."
-					]
-				},
-				{
-					"name": "Activate Incorporated Cypher {@recharge}",
-					"entries": [
-						"If a cypherid feels especially threatened, it activates one of the cyphers incorporated into its body. This is usually one of the following effects:",
-						"• Destructive ray (one target within 120 feet takes 12 ({@damage 3d8}) fire damage unless they succeed on a {@dc 13} Dexterity saving throw)",
-						"• Lightning burst (everything in a 5-foot-radius sphere takes 14 ({@damage 4d6}) lightning damage, or half that if they succeed on a {@dc 13} Dexterity saving throw)",
-						"• Gravity wave (everything in a 5-foot-radius sphere is knocked {@condition prone} and takes 10 ({@damage 3d6}) bludgeoning damage, or half that if they succeed on a {@dc 13} Dexterity saving throw)",
-						"• Phase changer (allows the cypherid to escape by moving through solid objects for one minute)",
-						"Alternatively, the GM can create other offensive, defensive, or utilitarian cypher-like effects similar to the above, with a {@dc 13}."
-					]
-				},
-				{
-					"name": "Steal and Repair",
-					"entries": [
-						"The cypherid extends a glassy tendril into the targeted character's equipment and attempts to steal one cypher and add the device to its own body. If the cypherid is injured, this repairs 7 points of damage. If this takes it over its normal hit point total, it gains the excess amount as temporary hit points. The target can resist this grab attempt with a successful {@dc 13} Strength or Dexterity saving throw."
-					]
-				},
-				{
-					"name": "Spawn {@recharge}",
-					"entries": [
-						"A group of four cypherids can focus on a target who carries two or more cyphers, causing the cyphers to fuse together and animate as a new cypherid. The target can prevent this from happening with a {@dc 13} Intelligence saving throw. The character has disadvantage on this saving throw because of the cypherid's swarm targeting ability."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"F",
-				"L",
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			"conditionInflict": [
-				"prone"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Cypherids are automatons that are essentially {@footnote an animate accumulation of cyphers|Some people familiar with the numenera speculate that cypherids are a simpler progenitor of a cynoclept, presumably having found a permanent way to maintain its intellect.|Cynoclept, page 159}. Like vermin, they sometimes conglomerate in ruins. They flit, clamber, slide, or trundle along on limbs made of disparate devices, though there is an overall spider-like body structure to the creature. A cypherid generally doesn’t reach dimensions larger than a couple of feet across. Like an insect, a cypherid seems driven by simple motives. In this case, it is to accumulate more cyphers to add to itself as older components get used up or burn out.",
-							{
-								"type":"inset",
-								"entries":[
-									"Some sages of the numenera believe cypherids could be a primitive kind of cynoclept, perhaps one that hasn’t acquired any amber crystal to form a protective shell. Other suggest that cypherids are the animate remnants of a destroyed cynoclept trying to restore their original form."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Intermittently Intelligent",
-								"entries":[
-									"Most cypherids are not intelligent and do not communicate. A few that absorb cyphers that allow them to communicate with other machines (or similar abilities) can gain intelligent behaviors and advanced motives, for a time. Such a creature that gains, loses, and gains intelligence again likely realizes the fragility of its higher functioning and focuses its efforts on acquiring more cyphers that can prevent it from again lapsing into a beast-like state."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"One to three cyphers can be salvaged from a cypherid’s body."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Dabirri",
-			"source": "AotA",
-			"page": 163,
-			"size": "S",
-			"type": "construct",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 8,
-				"formula": "2d6 + 1"
-			},
-			"speed": {
-				"swim": 10
-			},
-			"str": 6,
-			"dex": 10,
-			"con": 11,
-			"int": 1,
-			"wis": 5,
-			"cha": 1,
-			"senses": [
-				"blindsight 30 ft."
-			],
-			"passive": 7,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-					"blinded",
-					"charmed",
-					"deafened",
-					"exhaustion",
-					"frightened",
-					"paralyzed",
-					"petrified",
-					"poisoned",
-					"prone"
-				],
-				"cr": "1/4",
-				"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The dabirri makes two tendril sting attacks."
-					]
-				},
-				{
-					"name": "Tendril Sting",
-					"entries": [
-						"{@atk mw} {@hit 2} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d8}) necrotic damage. If the attack is a critical hit, the jolt of disrupting energy hops to another creature within 5 feet and deals 4 ({@damage 1d8}) necrotic damage to that creature."
-					]
-				}
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"N"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A dabirri is an artificial water-dwelling construct created by taking the heart of a human-sized creature and placing it in a hard transparent shell. A dabirri does not eat and is not intelligent, but it instinctively attacks warm-blooded creatures with its venomous tendrils. A typical specimen is anywhere from 1 to 3 feet across, with the tendrils adding an additional length all around equal to the body’s diameter. It moves by a combination of fine jets of water and swimming with its tendrils.",
-							{
-								"type":"entries",
-								"name":"Deadly Sting",
-								"entries":[
-									"Unlike a jellyfish, a dabirri’s sting isn’t poisonous. Instead, it jolts its opponent with a pulse of energy that transmits a signal that tells the target’s cells to shut down and die. Although its individual attacks are weak, they tend to be found in swarms, and the aggregate effect of these stings can eventually overwhelm even large targets."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Fabricated Entity",
-								"entries":[
-									"Although it has living components, a dabirri cannot reproduce. Presumably, another, larger creature or numenera structure continues to produce them by harvesting the hearts of suitable creatures."
-								]
-							},
-							{
-								"type":"inset",
-								"entries":[
-									"Within the central portion of a Dabirri is a tiny dollop of a useful chemical that restores 1 point of damage if injected or taken internally."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Dark Fathom",
-			"source": "AotA",
-			"page": 164,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 20,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 190,
-				"formula": "20d8 + 100"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 14,
-			"dex": 10,
-			"con": 20,
-			"int": 12,
-			"wis": 14,
-			"cha": 10,
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 18,
-			"resist": [
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks"
-				}
-			],
-			"immune": [
-				"necrotic",
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr":"17",
-			"trait": [
-				{
-					"name": "Consume Ranged Attacks",
-					"entries": [
-						"The dark fathom's singularity automatically draws in and consumes all ranged attacks directed at it, whether they are matter (such as arrows and crossbow bolts) or energy (including numenera rays and spell effects like scorching ray and disintegrate). The creature suffers no harm from these attacks. The only ranged attacks it can't absorb are mental (such as phantasmal killer), magnetic energy, or extradimensional."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The dark fathom's attacks are treated as if magical."
-					]
-				},
-				{
-					"name": "Gravity Field",
-					"entries": [
-						"Any creature within 5 feet of a dark fathom must succeed on a {@dc 19} Strength saving throw at the start of their turn. Those who fail are partially drawn into the singularity and take 22 ({@damage 5d8}) force damage. Characters reduced to 0 hp from this damage are completely drawn into the singularity, consumed, and utterly destroyed."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Singularity Pull",
-					"entries": [
-						"A dark fathom can use its singularity to pull all creatures and objects within 30 feet toward it so they end up next to it. Creatures can resist this pull with a successful {@dc 19} Strength saving throw."
-					]
-				},
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}12 ({@damage 3d6 + 2}) bludgeoning damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Absorb (Recharge 5-6)",
-					"entries": [
-						"As its reaction, by using the force of its singularity, a dark fathom can attempt to pull in and absorb an object or energy source within 10 feet, so long as its target is smaller than itself. For example, it might absorb a door blocking its way, a stone from a catapult launched at it, or the power core of a numenera structure. If the target is an object, it takes 45 ({@damage 10d8}) force damage; if this reduces the object to 0 hit points, it is disintegrated by the dark fathom's singularity. If the target is an energy source, roll {@dice 10d8} and subtract this result from the damage the energy source deals; if this reduces the energy source's damage to 0, it is completely destroyed by the singularity. After the dark fathom uses this ability, on its next turn it cannot use its singularity for anything."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"B",
-				"O"
-			],
-			"miscTags": [
-				"MW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A dark fathom looks like a darkly armored humanoid with a black hole in the center of its chest, surrounded by a vortex of swirling energy—or perhaps the black hole is its chest, and the creature is built around that empty space. The rest of its body is completely obscured by its armor and helmet. Part mechanical and part biological, a dark fathom is an engine of destruction from aeons past, pursuing a solitary mission that only it understands.",
-							{
-								"type":"entries",
-								"name":"Singularity Heart",
-								"entries":[
-									"The swirling hole in a dark fathom’s chest is an artificial singularity, an area of gravity so intense that matter and energy cannot escape it. This is the creature’s power source and a {@footnote devastating weapon|Sometimes when a dark fathom uses its singularity pull, the strain temporarily overwhelms it, stunning it on its next turn.}. Anyone nearby can feel a slight current of air pulling toward the creature, and it is common to see small pieces of debris and even tiny creatures pulled into the singularity and destroyed."
-								]
-							},
-							{
-								"type":"inset",
-								"entries":[
-									"Although a dark fathom’s singularity resembles a sphere of annihilation, the singularity is an area of intense gravity, whereas the sphere is a magical hole in the universe. If the GM wants to mix magic and technology, certain things that affect the sphere might have a similar effect on the dark fathom. For example, holding a talisman of the sphere might give a character a round-by-round chance to control the dark fathom for a short time, pushing the dark fathom into a gate or portable hole might create a spatial rift, and so on. The dark fathom almost certainly would recognize the risks of these attacks and attempt to kill or absorb the source of the threat."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Inscrutable",
-								"entries":[
-									"A dark fathom is difficult to interact with. Although very intelligent, it doesn’t seem to understand any spoken languages. However, telepathy (whether the kind that works on living creatures or machine telepathy from a numenera device) allows characters to communicate with it and perhaps even to reason with it. A dark fathom can be bribed to move on instead of fighting, but it is interested only in exotic matter and energies (or information about where those things can be found). Some dark fathoms have their own agendas or interests as well, but their motive is always destruction, and that makes them dangerous."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"A dark fathom has mechanical and biomechanical parts that can be salvaged for {@dice 1d6} + 4 cyphers."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Deadeye",
-			"source": "AotA",
-			"page": 166,
-			"size": "H",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 195,
-				"formula": "17d12 + 85"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 10,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 18,
-			"dex": 10,
-			"con": 21,
-			"int": 20,
-			"wis": 15,
-			"cha": 13,
-			"save": {
-				"con": "+9",
-				"int": "+9",
-				"wis": "+6",
-				"cha": "+5"
-			},
-			"skill": {
-				"perception": "+6"
-			},
-			"senses": [
-				"darkvision 60 ft.",
-				"truesight 30 ft."
-			],
-			"passive": 16,
-			"resist": [
-				"bludgeoning",
-				"piercing",
-				"slashing"
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "12",
-			"trait": [
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The deadeye's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Psychic Onslaught",
-					"entries": [
-						"The deadeye projects psychic energy against up to three creatures within 60 feet or one creature within 120 feet. Each creature takes 28 ({@damage 8d6}) psychic damage, or half that with a successful {@dc 17} Intelligence saving throw."
-					]
-				},
-				{
-					"name": "Teleport",
-					"entries": [
-						"A deadeye can teleport to anywhere within about",
-						"1,000 miles. It also seems to have the ability to travel several hours into the past of its current location and then return to the true present when it wants to."
-					]
-				}
-			],
-			"senseTags": [
-				"D",
-				"U"
-			],
-			"actionTags": [
-				"Teleport"
-			],
-			"damageTags": [
-				"Y"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A deadeye — also known as a gravewatcher — is a 20-foot-diameter machine that takes great interest in the deaths of intelligent living things. It isn’t a murderer, unless forced to defend itself. Instead, it shows up right after one or more people have been killed to view the remains for several minutes, deploying an array of strange devices over the bodies. Sometimes, it appears before a lethal situation arises, as if it somehow knows that deaths are imminent. Wherever and whenever it is, a deadeye is always watching, always recording.",
-							{
-								"type":"entries",
-								"name":"Strange Announcements",
-								"entries":[
-									"When a deadeye shows up prior to a death (as opposed to afterward), it sometimes speaks using the tone, intonation, words, and knowledge of a creature whose remains it has previously recorded. Such pronouncements at first sound inane and without context. However, the meaning sometimes becomes clear as later events play out, when the mysterious message is revealed to have been a warning. Often, that realization comes too late. Rarely, it has been known to speak with the voice of someone that a person present knows to be dead, which can be very disturbing."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Non-aggressive",
-								"entries":[
-								 "A deadeye never initiates an attack but will defend itself. It persists in this onslaught only if those attacking it continue their own attacks. If overmatched, a deadeye teleports away, potentially also moving some hours into the past."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The remains of a gravewatcher contains {@dice 1d6} cyphers, {@dice 1d10} oddities, and {@dice 1d2} relics."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Disassembler",
-			"source": "AotA",
-			"page": 167,
-			"size": "L",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 104,
-				"formula": "11d10 + 44"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 19,
-			"dex": 15,
-			"con": 18,
-			"int": 14,
-			"wis": 13,
-			"cha": 13,
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 14,
-			"resist": [
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks"
-				}
-			],
-			"immune": [
-				"poison",
-				"psychic"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"understands most languages after hearing them for a few minutes"
-			],
-			"cr": "5",
-			"trait": [
-				{
-					"name": "Inorganic Destruction",
-					"entries": [
-						"The dissembler sometimes turns artificial objects and portions of structures it can see within 5 feet of it into liquid and gas (destroying them). If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature is subject to one or more Disassembly Claw attacks; on a hit, instead of dealing damage, the object is affected as follows.",
-						"If the object touched is unliving armor or a shield being worn or carried, it takes a permanent and cumulative -1 penalty to the AC it offers (some magical armor and shields shed this penalty within a day, unless destroyed). Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held nonliving weapon, the weapon takes a permanent and cumulative -1 penalty to damage rolls (magical weapons shed this penalty within a day, unless destroyed). If its penalty drops to -5, the weapon is destroyed."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The disassembler makes three attacks with its disassembly claws. If a target is wearing nonliving armor or wielding a nonliving weapon (such as armor and weapons made of iron), it makes one, two, or three attacks that affect objects as described in the Inorganic Destruction trait. (The other one or two attacks against the target affect it as a normal attack.)"
-					]
-				},
-				{
-					"name": "Disassembly Claws",
-					"entries": [
-						"{@atk m} {@hit 7} to hit, reach 5 ft., one target. {@h}11 ({@damage 2d6 + 4}) piercing damage, or 21 ({@damage 5d6 + 4}) piercing damage if attacking a creature composed of inorganic or nonliving matter (such as most constructs and undead)."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"AOE"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A disassembler is a strange-looking artificial creature of glass and steel with six spindly metallic arms arranged around its circular midsection. Its upper half is all glaring green lights and mechanical protrusions, some of which might be sensory mechanisms. Its lower half is a broad engine that allows it to hover 3 feet off the ground. If it landed, the disassembler would be about 8 feet tall.",
-							{
-								"type":"entries",
-								"name":"Mad Wanderers",
-								"entries":[
-									"Disassemblers are artificially intelligent automatons that seem to have gone mad at some point. Now they act erratically—sometimes attacking creatures, sometimes ignoring them, sometimes destroying what they come across, sometimes wandering aimlessly.",
-									"A conversation with a disassembler is possible. They understand speech and, after listening to a language for a time, can often speak it in a very basic way. But the creature is just as likely to attack without provocation, perhaps in the middle of a conversation. Still, a well-spoken, intelligent, and quick-witted character might be able to figure out what a disassembler wants (at the moment) and convince it not to attack or perhaps to do something to aid them."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Potential Predators of the Living",
-								"entries":[
-									"The construct’s disassembling tools cannot affect organic matter, but this limitation might have been programmed into it—perhaps as a safety mechanism—rather than being a true inability. A disassembler with this prohibition removed would be a terror."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Dissector",
-			"source": "AotA",
-			"page": 169,
-			"size": "L",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 142,
-				"formula": "15d10 + 60"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 20,
-			"dex": 15,
-			"con": 18,
-			"int": 17,
-			"wis": 14,
-			"cha": 14,
-			"save": {
-				"con": "+8",
-				"int": "+7"
-			},
-			"skill": {
-				"medicine": "+6",
-				"nature": "+7",
-				"perception": "+6"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 16,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"several",
-				"learns new languages after listening for several minutes"
-			],
-			"cr": "9",
-			"trait": [
-				{
-					"name": "Ignore Defenses",
-					"entries": [
-						"A dissector can create specialized microtools that allow it to slice through and store any kind of organic tissue, as well as physical materials that are blocking access to its test subject. Its attacks ignore the AC granted by physical armor, but not from magic or force fields. Its attacks deal full damage against fleshy targets, even if the target would normally have resistance or immunity to bludgeoning, piercing, or slashing damage."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The dissector's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The dissector makes two manipulator attacks."
-					]
-				},
-				{
-					"name": "Manipulator",
-					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}50 ({@damage 10d8 + 5}) piercing or slashing damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"MW",
-				"RCH"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "This bulky artificial creature sports thick metallic arms articulated with stubby manipulators. Its lower body is a metallic tripod that gives the creature the ability to hover just above any solid surface or fly rapidly to distant locations. Dissectors are entirely motivated by the study of life itself. However, that study is apparently not grounded in respect, because their method of study requires that they completely dissect every organ of each new subject they acquire. Often, those organs are neatly embedded in metal containers. Of the original donor, nothing remains but parts.",
-							{
-								"type":"entries",
-								"name":"Surgical Tools",
-								"entries":[
-									"Each of a dissector’s manipulators is able to extrude a nanite scaffolding of far smaller instruments that can be selectively tuned to disrupt and cut flesh, limbs, organs, or other tissues within living creatures. Though it selects subjects and dissects them to death, it works on only one subject at a time and may take some time before selecting a new target, which means it doesn’t attack every living thing it comes across."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Negotiable Research",
-								"entries":[
-									"Though single-minded, a dissector maybe willing to negotiate if the PCsoffer to lead it to a brand-newkind of subject that it has neverpreviously studied. The dissectormight insist that the PCs allow itto extract one “unneeded” organfrom someone present, otherwisethe talk is concluded."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The remains of a destroyed dissector might hold {@dice 1d6 + 1} cyphers, an oddity, and perhaps a relic."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Dread Destroyer",
-			"source": "AotA",
-			"page": 170,
-			"size": "G",
-			"type": "construct",
-			"alignment": [
-				{
-				  "alignment": [
-					"N"
-				  ],
-				  "note": "or as programmed"
-				}
-			],
-			"ac": [
-				{
-					"ac": 25,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 676,
-				"formula": "33d20 + 330"
-			},
-			"speed": {
-				"walk": 40,
-				"climb": 30,
-				"swim": 40
-			},
-			"str": 30,
-			"dex": 10,
-			"con": 30,
-			"int": 14,
-			"wis": 14,
-			"cha": 13,
-			"save": {
-				"int": "+11",
-				"wis": "+11",
-				"cha": "+10"
-			},
-			"skill": {
-				"perception": "+11"
-			},
-			"senses": [
-				"blindsight 120 ft.",
-				"darkvision 120 ft.",
-				"tremorsense 120 ft."
-			],
-			"passive": 21,
-			"resist": [
-				"fire",
-				"thunder"
-			],
-			"immune": [
-				"lightning",
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned",
-				"prone"
-			],
-			"cr": "30",
-			"trait": [
-				{
-					"name": "Legendary Resistance (3/Day)",
-					"entries": [
-						"If the dread destroyer fails a saving throw, it can choose to succeed instead."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The dread destroyer has advantage on saving throws against spells and other magical effects."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The dread destroyer's attacks are treated as if magical.",
-						"Self-repair. The dread destroyer automatically repairs 20 hit points at the start of its turn. It is only destroyed if it starts its turn with 0 hit points."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The dread destroyer can fire a missile and electrocute, or make six attacks: four slams, grapple (mandibles), and fire a missile."
-					]
-				},
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 19} to hit, reach 10 ft., one target. {@h}36 ({@damage 4d12 + 10}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Grapple",
-					"entries": [
-						"{@atk mw} {@hit 19} to hit, reach 10 ft., one target. {@h}17 ({@damage 2d6 + 10}) lightning damage. If the target is a Large or smaller creature, it is {@condition restrained} (escape DC 29) Until this grapple ends, target automatically takes 17 ({@damage 2d6 + 10}) lightning damage every round on the dread destroyer's turn, and the dread destroyer cannot grapple another target."
-					]
-				},
-				{
-					"name": "Missile",
-					"entries": [
-						"{@atk rw} {@hit 9} to hit, range 500 feet/1 mile, all targets within 100 feet of the impact point. {@h}13 ({@damage 2d10 + 2}) piercing damage plus 13 ({@damage 2d10 + 2}) fire damage; creatures in the blast area who succeed on a {@dc 19} Dexterity saving throw take half damage."
-					]
-				},
-				{
-					"name": "Electrocute",
-					"entries": [
-						"Each creature within 10 feet of the dread destroyer takes 10 ({@damage 3d6}) lightning damage."
-					]
-				}
-			],
-			"legendary": [
-				{
-					"name": "Attack",
-					"entries": [
-						"The dread destroyer makes one slam attack."
-					]
-				},
-				{
-					"name": "Move",
-					"entries": [
-						"The dread destroyer moves up to half its speed."
-					]
-				},
-				{
-					"name": "Seize (Costs 2 Actions)",
-					"entries": [
-						"The dread destroyer makes one grapple attack."
-					]
-				}
-			],
-			"traitTags": [
-				"Legendary Resistances",
-				"Magic Resistance"
-			],
-			"senseTags": [
-				"B",
-				"SD",
-				"T"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"F",
-				"L",
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"MW",
-				"RCH",
-				"RW"
-			],
-			"conditionInflict": [
-				"restrained"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A dread destroyer is likely the most horrific thing on a battlefield. Unless you have an army on your side and are willing to lose a large portion of your forces, battle is unwise. Still, the greatest guardians often protect the greatest treasures. Only one of these automatons has been seen at a time, but holographic images have shown scenes (presumably from the distant past) when hundreds of dread destroyers crawled across a battlefield together. Although a single dread destroyer could launch an attack on an entire city, it is far more likely that you’ll find one defending an important, ancient site.",
-							{
-							  "type":"inset",
-							  "entries":[
-							  	{
-										"type":"quote",
-										"entries":[
-											"Imagine a tarrasque and a dread destroyer battling each other, two terrible destructive forces in perfect opposition. Their battlefield would quickly become a wasteland, and they might fight for weeks before one gained an advantage over the other."
-											],
-										"by":"Elmande, elf mage and scholar"
-									}
-							  ]
-							},
-							{
-								"type": "insetReadaloud",
-								"entries": [
-							    	{
-											"type":"quote",
-											"entries":[
-												"Makes a drow stronghold seem like a safe place in comparison. I’d bet on the machine, though, it’s got an advantage of range."
-											],
-											"by":"Faim Trubeard, dwarf veteran and prospector"
-										}
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Hybrid Construct",
-								"entries":[
-									"These giant war machines have organic brains and internal organs protected by a self-repairing metal shell. If communication can be established with its organic brain, a PC can reason with a dread destroyer, but convincing it to do something is very difficult, and usually the best option for survival is to flee until it has moved on to some other location."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Aquatic and Land Assault",
-								"entries":[
-									"Dread destroyers do not need to breathe, and can be encountered on land or underwater. Presumably they might be found in space, but they would require modifications to allow them to maneuver there."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The remains of a dread destroyer are a scavenger’s dream, yielding at least {@dice 1d20} oddities, {@dice 1d20} cyphers, and {@dice 1d6} relics."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Entrope",
-			"source": "AotA",
-			"page": 172,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 76,
-				"formula": "8d10 + 32"
-			},
-			"speed": {
-				"walk": 30,
-				"burrow": {
-					"number": 10,
-					"condition": "(ice and snow only)"
-				}
-			},
-			"str": 17,
-			"dex": 11,
-			"con": 18,
-			"int": 2,
-			"wis": 10,
-			"cha": 5,
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"immune": [
-				"cold"
-			],
-			"vulnerable": [
-				"fire"
-			],
-			"cr": "5",
-			"trait": [
-				{
-					"name": "Hibernation",
-					"entries": [
-						"An entrope remains active so long as there are suitable heat sources within 10 feet of itself. If no appropriate heat sources are within range, after about a minute it stops moving and begins to hibernate again. If attacked from beyond this range, it struggles to remain awake and has disadvantage on all of its rolls."
-					]
-				},
-				{
-					"name": "Cold Aura",
-					"entries": [
-						"Upon waking, an entrope generates a heat- absorbing field at immediate range, which also coats all objects and creatures in the area with a thin layer of frost.",
-						"At the start of each of its turns, each creature within 10 feet of it that fails a {@dc 17} Constitution save takes 5 ({@damage 1d10}) cold damage and gains disadvantage on actions that require movement. Cold auras from multiple entropes are additive.",
-						"Creatures with resistance or immunity to cold do not gain disadvantage from the cold aura."
-					]
-				},
-				{
-					"name": "Detect Heat",
-					"entries": [
-						"An entrope can sense the heat from warm- blooded living creatures up to 60 feet away. It knows the general direction they're in but not their exact locations."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The entrope makes two tentacle attacks."
-					]
-				},
-				{
-					"name": "Tentacle",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 10 ft., one target. {@h}10 ({@damage 2d6 + 3}) cold damage."
-					]
-				},
-				{
-					"name": "Spawn",
-					"entries": [
-						"Every point of cold damage the entrope deals is added to its hit points, whether the cold damage is caused by its cold aura or its tentacle attacks. When an entrope absorbs enough heat that its hit point total reaches 100, it spends its action spawning, becoming two entropes, each with half of the single entrope's hit points, rounded down."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack",
-				"Tentacles"
-			],
-			"damageTags": [
-				"C"
-			],
-			"miscTags": [
-				"AOE",
-				"MW",
-				"RCH"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "An entrope is an entity made of exotic biomineral that feeds on the heat given off by the bodies of living creatures. When it has absorbed enough heat, it can reproduce. They are usually discovered solo or in pairs, looking like thin statues that are cold to the touch— until they begin moving. An entrope is about 6 feet tall and nearly 15 feet long, but its odd hunched body shape makes it shorter than its actual length.",
-							{
-								"type":"entries",
-								"name":"Hibernation",
-								"entries":[
-									"An entrope can freeze motionless for years, centuries, or even longer until it detects a suitable heat source. It is unknown why they do not react to other sources of heat such as open flames and volcanic fissures, and is never found in warm environments, under open sky, or underwater. Most are found in subterranean locations, tunnels, and basements. They might be native to frigid regions, but it is more likely that they originated from an icy moon or rogue planet that crashed into the world and scattered them across its surface."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Primite Insticts",
-								"entries":[
-									"By all appearances, an entrope has animal intelligence at most. Its drives appear to be simple: feed on heat from living creatures, spawn, and repeat."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"Every entrope corpse has an organ called an entropic seed that can be removed and used as a detonation of frost cypher."
-								]
-							}
-						]
-			    }
-				]
-			}
-		},
-		{
-			"name": "Etterick",
-			"source": "AotA",
-			"page": 173,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 127,
-				"formula": "15d8 + 60"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 18,
-			"dex": 10,
-			"con": 18,
-			"int": 13,
-			"wis": 14,
-			"cha": 8,
-			"save": {
-				"str": "+7",
-				"con": "+7",
-				"int": "+4"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 12,
-			"resist": [
-				"bludgeoning"
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "8",
-			"trait": [
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The etterick's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The etterick makes two slam attacks or uses its magnetic pulse."
-					]
-				},
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}22 ({@damage 4d8 + 4}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Magnetic Pulse {@recharge 4}",
-					"entries": [
-						"The etterick emits a powerful magnetic pulse that deals 18 ({@damage 4d8}) force damage to all creatures within 30 feet, or half that with a successful {@dc 15} Dexterity saving throw. Creatures with a large amount of metal on their person (such as medium or heavy metal armor) must also succeed on a {@dc 15} Strength saving throw or be knocked {@condition prone} and back 10 feet."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Heavyweight",
-					"entries": [
-						"An etterick that is knocked {@condition prone} is 50% likely to fall toward an adjacent opponent. This deals 22 ({@damage 4d8 + 4}) bludgeoning damage, knocks the opponent {@condition prone}, and restrains the opponent with the weight of its body. If the character makes a successful {@dc 15} Dexterity saving throw, they take half damage and are not knocked {@condition prone} or {@condition restrained}. A {@condition restrained} character can free itself as an action by making a {@dc 15} Strength or Dexterity saving throw (character's choice). If the etterick believes this position is to its advantage, it remains {@condition prone}, otherwise it uses its move to stand up on its next turn."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"O"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"prone"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "The thing that people call an etterick is an automaton in the vague shape of a human, with transparent metal skin. Crawling around in its hollow interior is a swarm of insects that look like no other insects found anywhere. They control the machine through means that look like scuttling around and doing typical insect activities. An etterik is 7 to 8 feet tall, but thinner and slightly disproportionate compared to a human. If an etterick is destroyed, the insects inside swarm out and scatter, never to be seen again.",
-							{
-								"type":"entries",
-								"name":"Violent Communicator",
-								"entries":[
-									"Those who attempt to communicate with an etterick—or rather, with its hive-mind pilots that act as a singular entity— find it quite willing to talk. However, establishing that communication in the first place requires telepathy or a similar ability. The etterick will not (cannot?) share its origins and finds almost any mundane topics or meaningless niceties to be reason to attack. But it is amenable to bribery or straightforward negotiations (such as “We’ll leave this area immediately if you stop attacking us”). It seems to value most numenera items."
-								]
-							},
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-											"What is it?” Jul nocked another arrow and ducked behind the tree.",
-											"“Damned if I know.” Marlich whispered. He hid behind a pile of rotting logs.",
-											"“It looks like glass, but my arrow bounced off it like it was stone.”",
-											"“Yeah, but what are those things crawling around inside it? Are they trapped in there?”",
-											"“Look like bugs. Maybe they just crawled in there.”",
-											"“Or they’re controlling it ... ”",
-											"“They’re just bugs!”",
-											"“We’ve seen stranger things.”",
-											"“I’m not sure we have."
-							      ]
-							    }
-							  ]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"Looting through the remains of an etterick yields a bounty of 1d6 + 1 cyphers and a relic, all made of transparent metal."
-								]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Ferno Walker",
-			"source": "AotA",
-			"page": 174,
-			"size": "L",
-			"type": "beast",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 135,
-				"formula": "18d10 + 36"
-			},
-			"speed": {
-				"walk": 60
-			},
-			"str": 18,
-			"dex": 10,
-			"con": 16,
-			"int": 2,
-			"wis": 12,
-			"cha": 7,
-			"skill": {
-				"climb": "+7",
-				"perception": "+4"
-			},
-			"passive": 14,
-			"immune": [
-				"fire"
-			],
-			"cr": "8",
-			"trait": [
-				{
-					"name": "Mountain Agility",
-					"entries": [
-						"The ferno walker ignores difficult terrain resulting from broken, rocky, or steep terrain."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The ferno walker makes two bite attacks, or one bite and uses a held weapon or cypher."
-					]
-				},
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}22 ({@damage 4d8 + 4}) piercing damage."
-					]
-				},
-				{
-					"name": "Superheated Spew {@recharge 5}",
-					"entries": [
-						"The ferno walker vomits a super-hot liquid chemical in a 10-foot cone or a 30-foot line.",
-						"Each creature in the area must make a {@dc 15} Dexterity saving throw, taking 7 ({@damage 2d6}) acid damage and 7 ({@damage 2d6}) fire damage on a failed save, or half as much damage on a successful one."
-					]
-				}
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"A",
-				"F",
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Some people speculate that the ferno walker and the snow loper shared a common ancestor in the distant past, both being six-limbed mammals with a pair of usable hands. Regardless, the ferno walker is very different from its possible cousin. These predators supplement their diet of meat by ingesting large stones that sit in a special portion of their gut. Through an unknown process, {@footnote this organ produces extreme temperatures|Tanners and leatherworkers have attempted to use ferno walker skins to make heat-resistant armor, but so far all attempts have failed.}, heating the rocks so that there is a literal furnace in its belly at all times. A ferno walker can go for weeks without water.",
-							{
-								"type":"entries",
-								"name":"Semi-intelligent",
-								"entries":[
-									"Although ferno walkers do not use language, {@footnote they are more intelligent than they might appear|Some ancient civilization may have created ferno walkers by mixing the genes of creatures like red dragons and rhinoceroses to create a sturdy mount suitable for hot, hilly terrain.}. They are aloof and defensive, but if approached with peace, patience, and bribes of food, they might interact without violence. This is much harder if the ferno walker has young nearby (all persuasion and negotiation attempts have disadvantage)."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Great Mounts",
-								"entries":[
-									"Ferno walkers are sometimes captured and forced to become mounts. Other times, they befriend a humanoid and willingly become a mount and companion. Most can be trained to use cyphers and other simple devices, and a smart rider equips their mount with a weapon or device that it can use in its hands."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Ganthanhar",
-			"source": "AotA",
-			"page": 175,
-			"size": "M",
-			"type": "elemental",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"containment suit"
-					]
-				}
-			],
-			"hp": {
-				"average": 120,
-				"formula": "16d8 + 48"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 14,
-			"dex": 14,
-			"con": 16,
-			"int": 17,
-			"wis": 12,
-			"cha": 11,
-			"save": {
-				"con": "+6",
-				"int": "+6"
-			},
-			"skill": {
-				"arcana": "+6",
-				"perception": "+4"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 14,
-			"resist": [
-				"cold",
-				"fire",
-				"lightning",
-				"radiant"
-			],
-			"languages": [
-				"Ganthanhar",
-				"various others"
-			],
-			"cr": "6",
-			"trait": [
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The ganthanhar's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bodiless",
-					"entries": [
-						"A ganthanhar doesn't have a physical body, so it can't use cyphers or other devices that require a living metabolism (such as most pills and injections). They can still manipulate objects, allowing them to use other items (including cyphers and relics)."
-					]
-				},
-				{
-					"name": "Death Throes",
-					"entries": [
-						"If a ganthanhar's hit points reach 0, its suit ruptures and releases the dying creature's radiation in an explosion. Each creature within 30 feet of it must make a {@dc 14} Dexterity saving throw, taking 14 ({@damage 4d6}) fire damage on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Protective Suit",
-					"entries": [
-						"A ganthanhar's containment suit gives them resistance to cold, fire, lightning, and radiant damage. A desperate, injured ganthanhar can abandon its suit to exist as an independent energy being. Without its suit, a ganthanhar's radiation aura inflicts double damage and its speed increases to 500 feet, but its AC decreases to 10 and it will perish within a few hours if it doesn't get back into its suit."
-					]
-				},
-				{
-					"name": "Radiation Aura",
-					"entries": [
-						"A ganthanhar constantly emits dangerous radiation out to an immediate distance. At the start of each of the ganthanhar's turns, each creature within 10 feet of it takes 3 ({@dice 1d6}) fire and 3 ({@damage 1d6}) radiant damage. Ganthanhars are immune to their own radiation and that of other ganthanhars."
-					]
-				},
-				{
-					"name": "Radiation Blast",
-					"entries": [
-						"{@atk rw} {@hit 5} to hit, range 30/60 ft., one target. {@h}21 ({@damage 6d6}) fire damage and 21 ({@damage 6d6}) radiant damage."
-					]
-				},
-				{
-					"name": "Venting",
-					"entries": [
-						"If a ganthanhar is struck by a critical hit with a melee weapon, radiation from its suit leaks out, damaging the attacker for 3 ({@dice 1d6}) fire and 3 ({@damage 1d6}) radiant damage. If the critical hit is from a ranged weapon, this vented radiation instead strikes an opponent within 5 feet."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"F",
-				"R"
-			],
-			"miscTags": [
-				"AOE",
-				"RW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Ganthanhars look like four-armed, armored humanoids with digitigrade legs. Where their heads should be is a cloud of swirling energy containing a few mechanical or organic devices resembling eyes.",
-							{
-								"type":"entries",
-								"name":"Ascended Energy Form",
-								"entries":[
-									"Ganthanhars claim to be a race of advanced beings who experimented with extradimensional energies to make themselves immortal. Their experiments apparently succeeded in some respects, but their bodies have mostly been transformed into energy and they must wear special suits to prevent their physical forms from completely dissipating. Having exhausted all known remedies for their medical condition, they sift through lost civilizations in search of answers."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Arrogant",
-								"entries":[
-									"Ganthanhars don’t believe that other species have the capability to help with their specific needs. If they see someone using an unfamiliar piece of numenera that they think can help them, they will try to steal it or at least offer to trade for it."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"A ganthanhar’s suit can be salvaged for one or two cyphers and one or two oddities."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Gazer",
-			"source": "AotA",
-			"page": 176,
-			"size": "T",
-			"type": "construct",
-			"alignment": [
-				{
-				  "alignment": [
-					"N"
-				  ],
-				  "note": "or as programmed"
-				}
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 7,
-				"formula": "3d4"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 100,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 6,
-			"dex": 15,
-			"con": 11,
-			"int": 11,
-			"wis": 10,
-			"cha": 7,
-			"save": {
-				"dexterity": "+4"
-			},
-			"skill": {
-				"perception": "+2"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 12,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned",
-				"prone"
-			],
-			"cr": "1/8",
-			"trait": [
-				{
-					"name": "Intense Light",
-					"entries": [
-						"Although a gazer's beam only inflicts a small amount of damage, it is capable of cutting through very tough materials, including wood, stone, and steel. A gazer trying to damage an object treats any object AC less than 18 as AC 10."
-					]
-				},
-				{
-					"name": "Swarm Targeting",
-					"entries": [
-						"If two or more gazers attack the same target, each gazer gains advantage on its attack roll."
-					]
-				},
-				{
-					"name": "Sharpshooter",
-					"entries": [
-						"A gazer's attacks ignore half cover and three-quarters cover."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Red Beam",
-					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 100/120 ft., one target. {@h}5 ({@damage 1d6 + 2}) fire damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"F"
-			],
-			"miscTags": [
-				"RW"
-			],
-			"tokenUrl":"",
-			"fluff":{
-				"entries": [
-					{
-						"type":"entries",
-						"entries":[
-							"A gazer is a levitating metallic spherical automaton, about 1.5 feet in diameter. Various bits of equipment and blinking lights festoon a gazer’s battered metal-alloy body. A concavity on one side of the sphere incessantly emits a beam of scarlet light. The red beam can intensify in a moment, creating a ray capable of burning through nearly anything.",
-							{
-							"type":"entries",
-							"name":"Flying Tactics",
-							"entries":[
-								"Groups of gazers fly in a spherical formation, which allows them to present the maximum possible perception and threat surface. Depending on the locations of their opponents, they may arrange themselves around or in the middle of their foes. Formations of six to twelve gazers might be found defending ancient ruined installations. Sometimes a lone gazer is encountered as a companion of a creature who reprogrammed it to act as a servitor."]
-							},
-							{
-								"type":"entries",
-								"name":"Old Programming",
-								"entries":[
-									"A gazer usually interacts only by flashing its beam in coded bursts, accompanied by eerie bleats of electronic static. Most active gazers follow a program to defend a location, reconnoiter a wider area, or seek and destroy those who match profiles held in their machine brains. However, if any group of gazers is interfered with too much, they attempt to eradicate the perceived threat."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Legacy of Ancient War",
-								"entries":[
-									"Gazers are speculated to be antiques of a forgotten war that were originally {@footnote forged by the millions|Some explorers have reported caches of sphere- shaped numenera that turn out to be destroyed gazers. Often, a few of these automatons are still active...}. Only a handful remain active. However, if one of the ancient warehouses were discovered, that number could radically increase."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"A swarm of six to twelve gazers may be salvaged for up to 1d6 cyphers."
-									]
-							}
-						]
-					}
-				]
-			}
-		},
-		{
-			"name": "Glaxter",
-			"source": "AotA",
-			"page": 177,
-			"size": "L",
-			"type": "aberration",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 152,
-				"formula": "16d10 + 64"
-			},
-			"speed": {
-				"walk": 30,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 16,
-			"dex": 10,
-			"con": 18,
-			"int": 16,
-			"wis": 15,
-			"cha": 16,
-			"save": {
-				"con": "+7",
-				"int": "+6"
-			},
-			"skill": {
-				"arcana": "+6",
-				"anythreeknowledgeskills": "+6"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 12,
-			"resist": [
-				"bludgeoning"
-			],
-			"conditionImmune": [
-				"grappled",
-				"prone",
-				"restrained"
-			],
-			"languages": [
-				"Common",
-				"several others"
-			],
-			"cr": "8",
-			"trait": [
-				{
-					"name": "Amorphous",
-					"entries": [
-						"The glaxter can move through a space as narrow as 4 inches wide without squeezing."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The glaxter's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The glaxter can make up to three pseudopod attacks, but prefers to fire two telekinetic bolts at range."
-					]
-				},
-				{
-					"name": "Pseudopod",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}21 ({@damage 4d8 + 3}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Telekinetic Bolt",
-					"entries": [
-						"{@atk rw} {@hit 6} to hit, range",
-						"30/100 ft., one target. {@h}27 ({@damage 6d8}) force damage."
-					]
-				}
-			],
-			"traitTags": [
-				"Amorphous"
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"B",
-				"O"
-			],
-			"miscTags": [
-				"MW",
-				"RW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Glaxters are sentient collections of eye-studded chunks of flesh, able to rearrange their overall shape as needed. When at rest, they look like a mound of lumpy, odd-colored flesh with bright crystalline eyes all over. When active, they assume either a floating spheroid shape or (when interacting peacefully with humanoids) {@footnote something approximating a large humanoid form|Were the ancient ancestors of glaxters creatures like gibbering mouthers? Or are gibbering mouthers the degenerate mutated cousins of glaxters?}, with either form often orbited by small discrete pieces of itself.",
-							{
-								"type":"entries",
-								"name":"Malleable",
-								"entries":[
-									"Although not completely fluid, a glaxter’s component pieces are the size of a human fist, and a glaxter can pass through any barrier that its smallest piece can move through, such as through a pipe or between the bars of a prison cell."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Parts of a Whole",
-								"entries":[
-									"When pieces of a glaxter are in direct contact with each other, nerve tissue on the surface automatically connects them and lets the unified pieces act as one entity. They can separate smaller pieces ({@footnote remote nodules|Use stats for basic automaton, type one, two, or three (depending on its size), except with the aberration type.|Basic automaton page 246}), programming them with simple instructions and reconnecting later to absorb the disconnected pieces’ memories."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Social Blob",
-								"entries":[
-									"laxters communicate audibly by telekinetically vibrating the air to create the sound of words. Each glaxter has its own areas of interest—botany, social structure, thermodynamics, and so on—and observes things to further their knowledge. Multiple glaxters in the same place often exchange nodules (they do not explain whether this is communication or mating). They sometimes send out remote nodules with instructions to find interesting creatures and lead them back to its main body (so it can discuss a research proposition) or to test their reactions."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Klowledgeable and Noisy",
-								"entries":[
-									"Glaxters present themselves as dispassionate but curious observers of the creatures and locations of the world. They prefer to watch rather than interact. When they decide they are done observing and ready to leave, they may choose to answer questions about their areas of knowledge. One may follow a group of PCs for hours or days, all the while insisting that the characters should act normally, as if it wasn’t there, so it can observe their behavior or the functioning of a specific pie"
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"A glaxter’s large bulk can be salvaged for 1d6 cyphers."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Gleresisk",
-			"source": "AotA",
-			"page": 178,
-			"size": "S",
-			"type": "aberration",
-			"alignment": [
-				{
-				  "alignment": [
-					"U"
-				  ],
-				  "note": "or neutral evil when intelligent"
-				}
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 64,
-				"formula": "16d6 + 16"
-			},
-			"speed": {
-				"walk": 5,
-				"fly": {
-					"number": 60,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 8,
-			"dex": 16,
-			"con": 12,
-			"int": 3,
-			"wis": 13,
-			"cha": 4,
-			"save": {
-				"intelligence": "-2"
-			},
-			"skill": {
-				"perception": "+3"
-			},
-			"passive": 13,
-			"immune": [
-				"bludgeoning"
-			],
-			"languages": [
-				"none",
-				"or as its most recently consumed mind"
-			],
-			"cr": "4",
-			"action": [
-				{
-					"name": "Tendrils",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}17 ({@damage 5d6}) psychic damage. If the target is Medium or smaller, it is {@condition grappled} (escape {@dc 13})."
-					]
-				},
-				{
-					"name": "Extract Brain",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one {@condition incapacitated} humanoid {@condition grappled} by the gleresisk. {@h}17 ({@damage 5d6}) psychic damage. If this damage reduces the target to 0 hit points, the gleresisk kills the target by extracting and absorbing its brain. The gleresisk then releases its opponent, which falls {@condition prone}, dead.",
-						"A typical humanoid brain of Intelligence 7 to 13 increases the gleresisk's Intelligence to 13 for about a day. Less- or more- intelligent brains make the glerisisk less or more intelligent for this period of time.",
-						"If more than one gleresisk is grappling a creature when it dies from this ability, all of them absorb a portion of the creature's brains and intellect, forming a fragmented collective mind.",
-						"A gleresisk can extract the brain of a creature that died from something other than its attacks, but doing so means it retains its heightened intellect for a much shorter time depending on how long the creature had been dead\u2014approximately halving the duration for every 10 minutes the creature was dead before its brain was extracted (half a day after 10 minutes, one-fourth of a day after 20 minutes, and so on)."
-					]
-				}
-			],
-			"damageTags": [
-				"Y"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"grappled"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "This head-sized mass of yellowish floating goo has blubbery, foam-like flesh and a parade of trailing tendrils. It might be mistaken for a seed pod of a particularly large plant blowing in the wind—until it turns against the wind and dives for newly-perceived prey. Gleresisks can be found alone or in drifting flocks of three to ten.",
-							{
-								"type":"entries",
-								"name":"Mind Eater",
-								"entries":[
-									"A gleresisk absorbs minds by physically sucking brain matter into itself. The victim’s knowledge and memories become the gleresisk’s. When it eats a mind, it becomes a conscious and intelligent creature for one day, during which time it can plan, pick up previously conceived projects, and so on, until it metabolizes the stolen brain tissue and once again reverts to a predator with merely animal instincts."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Deceptive Absorption",
-								"entries":[
-									"A gleresisk can mimic speech and even act with the motivations of someone’s mind who was recently consumed, but that’s just a ruse. It has its own agenda, which probably involves methods of securing future minds on which to feed in relative safety."
-						    ]
-			        },
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "If you dream that your mind was absorbed by a gleresisk, how do you know if it’s really a dream, or merely the last thoughts of your absorbed brain?"
-							      ]
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Golthiar",
-			"source": "AotA",
-			"page": 179,
-			"size": "M",
-			"type": "plant",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 52,
-				"formula": "8d8 + 16"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 17,
-			"dex": 10,
-			"con": 15,
-			"int": 10,
-			"wis": 10,
-			"cha": 7,
-			"save": {
-				"str": "+5",
-				"wis": "+2"
-			},
-			"skill": {
-				"climb": "+5",
-				"perception": "+2"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 12,
-			"resist": [
-				"bludgeoning",
-				"piercing"
-			],
-			"vulnerable": [
-				"fire"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Regeneration",
-					"entries": [
-						"A golthiar regains 10 hit points at the start of its turn if it has at least 1 hit point and is in direct sunlight."
-					]
-				},
-				{
-					"name": "Flash Sensitivity",
-					"entries": [
-						"Unexpected exposure to bright light is disorienting for a golthiar. The first time it is exposed to a flash of bright light during an encounter, it must make a Wisdom saving throw against the light's DC (or {@dc 11} for a source without a DC). Failure means the golthiar is {@condition incapacitated} on its next turn."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The golthiar makes a spear attack with one arm and a bash attack with its other one."
-					]
-				},
-				{
-					"name": "Spear",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) piercing damage."
-					]
-				},
-				{
-					"name": "Bash",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Light Blast {@recharge}",
-					"entries": [
-						"About one in four golthiars have the ability to create a burst of light that affects all opponents within 30 feet. Each creature affected must make a {@dc 12} Dexterity saving throw, taking 9 ({@damage 2d6 + 2}) radiant damage on a failed save, or half as much damage on a successful one."
-					]
-				}
-			],
-			"traitTags": [
-				"Regeneration"
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"P",
-				"R"
-			],
-			"miscTags": [
-				"MW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Golthiars are humanoid creatures of woody muscle and bark-like skin that smell of sap. Their bulbous heads each have only a single eye surrounded by a fringe of jagged petals. They are quick and brutal despite their plant ancestry. A golthiar stands about 6.5 feet tall. Golthiars usually act as part of a team, coordinating their attacks through squirts of beamed color that is invisible to most people. The creatures direct the beams at each other or display them on a wall or ceiling that all the golthiars in an area can see.",
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "A bard told me that her see invisibility spell allowed her to see the flashes of light that golthiars use to communicate with each other. She is still working out the nuances of their language, but they appear to be as intelligent as you or I, with a complex vocabulary and nuanced phrasing."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "If you and your bard friend want to talk to plants, that’s on you. Me, I’ll stick to using them as garnish for my meat."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							},
-							{
-								"type":"entries",
-								"name":"Guardian Sprouts",
-								"entries":[
-									"{@footnote Golthiars are plants|Golthiars probably come from a deliberate mutated gene added to many different kinds of trees.}, and are planted rather than born. Underground seedpods “ripen” in groups of four to six at a time, push to the surface, and peel open to reveal wet, wrinkly creatures the size of adult humans. Within an hour, the creatures completely mature into soldiers able to survive for centuries on sun and nutrients gathered from burying themselves in soil every few days."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Crafted Growths",
-								"entries":[
-									"Trees that produce golthiar seedpods are not always similar in appearance. Sometimes they have great fronds, other times needles, and other times leaves. It’s almost as if the {@footnote pods that ripen beneath the ground are not part of the original tree’s growth.|If a defeated golthiar is planted in the ground and carefully tended, a new grove of golthiar saplings may spring up within a few weeks.}"
-						    ]
-			        },
-							{
-								"type":"inset",
-								"entries":[
-									"In places where the numenera is active, even plant creatures such as shambling mounds and treants may sprout golthiar pods. Intelligent plant creatures react to this much like humanoids do to maggots in wounds, even though golthiars usually act friendly toward them. Lower-intelligence plant creatures seem to instinctively recognize the resulting golthiars as kin and allies."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Purposeful",
-								"entries":[
-									"Golthiars not guarding, attacking, or scouting something wither and die within a few months. Those without orders could be willing to find a new command, but communicating with a golthiar requires knowing how to produce and decode the pulsating beams of light preferred by the creatures."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Grey Sampler",
-			"source": "AotA",
-			"page": 181,
-			"size": "L",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 102,
-				"formula": "12d10 + 36"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 20,
-			"dex": 12,
-			"con": 16,
-			"int": 11,
-			"wis": 12,
-			"cha": 10,
-			"skill": {
-				"perception": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"any one"
-			],
-			"cr": "4",
-			"trait": [
-				{
-					"name": "Charge",
-					"entries": [
-						"If the grey sampler moves at least 30 feet straight toward a target and then hits it with a surgical blades attack on the same turn, the target takes an extra 10 ({@damage 3d6}) piercing damage. The target must succeed on a {@dc 15} saving throw or be pushed back 10 feet and knocked {@condition prone}."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Surgical Blades",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}19 ({@damage 4d6 + 5}) slashing damage."
-					]
-				},
-				{
-					"name": "Process Brains",
-					"entries": [
-						"As a bonus action, a grey sampler can attempt to remove the brains of an {@condition unconscious}, dead, {@condition paralyzed}, or completely immobilized creature. If the target dies, it extracts the creature's brain and processes it into sludge."
-					]
-				}
-			],
-			"traitTags": [
-				"Charge"
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"prone"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A grey sampler is a flying automaton with asymmetrical construction, measuring almost 10 feet in diameter. Where its head should be is an angular funnel that roars and vibrates with endless fury. One of its limbs splits into a mess of slicing and scissoring blades. The grey sampler uses this limb to subdue specimens, separate cranial matter from clinging flesh and bone, and deposit the freed brain into its head-funnel. Somewhere in the grey sampler’s chest, the solid matter is processed into pinkish slush. The automaton’s other limb is more like a metallic, hollow tentacle that expels processed cranial matter. Most of the time, the cranial matter is sprayed behind the automaton in a wide, even arc, as if it’s spreading fertilizer or seeds.",
-							{
-								"type":"entries",
-								"name":"Hidden Construction",
-								"entries":[
-									"Grey samplers have a disconcerting ability to build themselves out of much smaller parts, too tiny to see without the aid of powerful numenera. This means that small fleets of them can arise anywhere, building themselves in secret, until an unknowable signal passes among them, and they emerge for the next harvest."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Determined",
-								"entries":[
-									"A grey sampler can communicate, but its main interest is directing potential victims to hold still so it can do its job. If asked who gave it the job or what it ultimately wants to accomplish, a grey sampler either doesn’t answer or says, “The fruit of our harvest prepares the way.” If someone who can talk to machines or who is otherwise skilled with numenera devices discovers a fleet of grey samplers building themselves from nearby components, they might be able to direct the fleet to self-destruct by making a DC 17 Intelligence (Arcana) check."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The remains of a destroyed grey sampler might hold a cypher or two."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Griefsteel",
-			"source": "AotA",
-			"page": 182,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"A"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 171,
-				"formula": "18d8 + 90"
-			},
-			"speed": {
-				"walk": {
-					"number": 30,
-					"condition": "(some also have fly 60 ft.)"
-				}
-			},
-			"str": 21,
-			"dex": 12,
-			"con": 20,
-			"int": 12,
-			"wis": 12,
-			"cha": 12,
-			"save": {
-				"str": "+9",
-				"con": "+9"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 15,
-			"resist": [
-				"bludgeoning"
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"one or two ancient languages"
-			],
-			"cr": "12",
-			"trait": [
-				{
-					"name": "Emotional Feedback",
-					"entries": [
-						"Attempts to mentally communicate with the griefsteel or connect to it with machine ports transmits the full force of its loss and trauma to the communicating creature's mind. The attempting creature must succeed on a {@dc 13} Wisdom saving throw or be {@condition stunned} for one round."
-					]
-				},
-				{
-					"name": "Gullible",
-					"entries": [
-						"A griefsteel desperately wants to believe anything that will momentarily distract it from its misery. It has disadvantage on rolls to see through disguises or recognize when someone is lying to it. However, once it realizes it has been tricked, it usually becomes angry and tries to harm those who deceived it."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The griefsteel's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The griefsteel makes three claw attacks and uses its energy ray."
-					]
-				},
-				{
-					"name": "Claw",
-					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}32 ({@damage 5d10 + 5}) slashing damage."
-					]
-				},
-				{
-					"name": "Energy Ray",
-					"entries": [
-						"{@atk rw} {@hit 5} to hit, range 60/120 ft., one target. {@h}11 ({@damage 3d6 + 1}) fire damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"F",
-				"S"
-			],
-			"miscTags": [
-				"MW",
-				"RW"
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A griefsteel is an automaton crafted to serve as a companion and guardian to another creature. However, that creature died ages ago, leaving the machine forever heartbroken. Although they are self-aware and able to learn, their emotion programs sometimes get them stuck in a mental loop from which they’re unable to escape. Whether encountered in the deeps of a lonely ruin or wandering across the empty landscape, a sorrow-wracked griefsteel is unlikely to ever find solace.",
-							{
-								"type":"entries",
-								"name":"Deliberately Solitary",
-								"entries":[
-									"A griefsteel might first ignore, then wail at someone trying to communicate with it. If communication attempts persist, it will finally strike out at whoever is bothering it, unless the intruder is extremely persuasive and calming."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Unpredictable",
-								"entries":[
-									"Unending sorrow makes a griefsteel’s behavior erratic. It’s not usually a threat, but it’s also not usually helpful. It’s too lost in its own misery to notice or care about others’ needs. Sometimes, the anguished automaton strikes out in fury over its loss, and an explorer who disrupted its iterative depressive cycle makes a good target—especially those who remind the griefsteel of what it’s lost. There is a chance that a griefsteel mistakenly believes that a character is its long-lost companion, but soon begins to have doubts, which makes it angry. A griefsteel has been known to mistake a stranger for the being who originally built it, and may beg to have its memory wiped or attack because it blames its creator for its sensitive emotional programming."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Many Forms",
-								"entries":[
-									"Griefsteels have different forms depending on who created them. What is presented here is a typical specimen, but individual griefsteels may have different attacks or special abilities."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"{@dice 1d6} cyphers can be salvaged from a griefsteel’s corpse."
-						    ]
-			        }
-					  ]
-			    }
-		   	]
-			}
-		},
-		{
-			"name": "Haneek",
-			"source": "AotA",
-			"page": 183,
-			"size": "M",
-			"type": "aberration",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 120,
-				"formula": "16d8 + 36"
-			},
-			"speed": {
-				"walk": 30,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 5,
-			"dex": 16,
-			"con": 16,
-			"int": 10,
-			"wis": 12,
-			"cha": 8,
-			"save": {
-				"dexterity": "+6"
-			},
-			"skill": {
-				"perception": "+4",
-				"stealth+6(orstealth-3foruptoanhourafterithas": "fed)"
-			},
-			"senses": [
-				"darkvision 30 ft."
-			],
-			"passive": 14,
-			"resist": [
-				"acid",
-				"piercing"
-			],
-			"immune": [
-				"bludgeoning"
-			],
-			"conditionImmune": [
-				"grappled",
-				"prone"
-			],
-			"cr": "5",
-			"trait": [
-				{
-					"name": "Amorphous",
-					"entries": [
-						"The haneek can move through a space as narrow as 1 inch tall and a few inches wide without squeezing."
-					]
-				},
-				{
-					"name": "Adhesive",
-					"entries": [
-						"The haneek can automatically adhere to anything that touches it. A Huge or smaller creature adhered to the haneek is also {@condition grappled} by it (escape {@dc 14}). Ability checks made to escape this grapple have disadvantage."
-					]
-				},
-				{
-					"name": "Grappler",
-					"entries": [
-						"The haneek has advantage on attack rolls against any creature {@condition grappled} by it."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Flesh Flap",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage plus 21 ({@damage 6d6}) acid damage."
-					]
-				},
-				{
-					"name": "Split",
-					"entries": [
-						"When a haneek that is Medium or larger takes 20 slashing damage or more from a single attack, it splits into two new haneeks if it has at least 15 hit points. Each new haneek has hit points equal to half the original haneek's, rounded down. New haneeks are one size smaller than the original haneek."
-					]
-				}
-			],
-			"traitTags": [
-				"Amorphous"
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"A",
-				"B"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"grappled"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Haneek are essentially sheets of almost transparent flesh that pass light with hardly any distortion. They can twist and fold themselves to move about like sidewinding snakes, gallop on faux limbs, and can even flap and glide through the air. Regardless of their shape, they smell a bit like rotting food, which is often the only warning those being hunted by a haneek have before the creature drops on them. They have been known to hang from branches or straddle doorways in high-traffic areas so creatures can walk into them.",
-							{
-								"type":"entries",
-								"name":"Visible Digestion",
-								"entries":[
-									"Once a victim is ensnared by a haneek, flesh-to-tissue contact begins to digest the prey. This sends a bloom of scarlet radiating through the haneek’s body, rendering it briefly visible as it feeds."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Unpredictable Lurker",
-								"entries":[
-									"A haneek is a hungry predator, but it sometimes “adopts” a character and merely follows them around, rather than trying to eat them. It hunts other creatures around the followed character instead. Because haneek are hard to spot, it’s often not initially apparent what’s going on, and it’s possible for PCs to meet another character who doesn’t realize they’re being followed by a haneek. Haneek seem somewhat intelligent, but they do not communicate or seem to have a language."
-						    ]
-			        }
-					  ]
-			    }
-		   	]
-			}
-		},
-		{
-			"name": "Herder",
-			"source": "AotA",
-			"page": 184,
-			"size": "L",
-			"type": "construct",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 76,
-				"formula": "9d10 + 27"
-			},
-			"speed": {
-				"walk": 50
-			},
-			"str": 18,
-			"dex": 12,
-			"con": 16,
-			"int": 6,
-			"wis": 14,
-			"cha": 6,
-			"save": {
-				"con": "+5"
-			},
-			"skill": {
-				"perception": "+4"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 14,
-			"resist": [
-				"bludgeoning",
-				"piercing",
-				"slashing"
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "3",
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The herder charges and makes a gore attack, or it makes two claw attacks."
-					]
-				},
-				{
-					"name": "Charge",
-					"entries": [
-						"If the herder moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 ({@damage 2d8}) piercing damage. If the target is a creature, it must succeed on a {@dc 14} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
-					]
-				},
-				{
-					"name": "Gore",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage, and the target must succeed on a {@dc 14} Constitution saving throw or be {@condition stunned} for one round."
-					]
-				},
-				{
-					"name": "Claw",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}18 ({@damage 2d10 + 4}) slashing damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"prone",
-				"stunned"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "This mechanical creature looks like a very large insect built of metal pipes and bone-colored ceramic. It bears a semicircle of metal spikes down its back, four sharp claws on each foot, and a hard, bone-like spur on the left side of its head. It stands nearly 3 feet tall, plus another 1 to 2 feet for its spikes.",
-							{
-								"type":"entries",
-								"name":"Gaurdians of Others",
-								"entries":[
-									"Herders were clearly created by someone or something, possibly for the protection of {@footnote catlike herbivores called enyi|For enyi, use stats for deer. They resemble long-eared, brown panthers.} (or possibly the enyi’s ancestors from thousands of generations in the past). Typically, one or two herders watch over a group of five to ten enyi (or some other nonaggressive herbivore if there are no enyi in the area). Often, one herder will move among the enyi and the other will follow nearby, out of sight, charging into view if combat occurs. Enyi react to herders as if the machines were harmless, perhaps due to a scent, sound, or vibration the herder uses to soothe the animals."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Threat Display",
-								"entries":[
-									"A herder displays various forms of aggression toward anything that it perceives as threatening its herd. The displays are nearly ritualistic in their order. First, the herder begins to make a loud clacking sound, created by rubbing its hind legs together. Characters often hear this sound long before they are close enough to see the herder; those with knowledge of the creature know to avoid the sound if possible. If the danger doesn’t go away, the herder rises up on its hind legs, doubling its height. The final sign of aggression before a herder attacks is that it drops its head and thumps its ceramic spur against the ground, hard enough for PCs to feel the collision beneath their feet. The first display of aggression is passive and ongoing; the last two each take one round."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Ruthless",
-								"entries":[
-									"A herder’s main objective is to defend their enyi, but once they begin combat, they don’t stop, even if the enyi no longer seem to be in danger. To a herder, once a threat, always a threat."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"Characters can scavenge one random cypher from a herder’s body."
-						    ]
-			        }
-					  ]
-			    }
-		    ]
-			}
-		},
-		{
-			"name": "Hungry Pennon",
-			"source": "AotA",
-			"page": 185,
-			"size": "M",
-			"type": "aberration",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 71,
-				"formula": "13d8 + 13"
-			},
-			"speed": {
-				"walk": 5,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 17,
-			"dex": 15,
-			"con": 12,
-			"int": 8,
-			"wis": 12,
-			"cha": 14,
-			"save": {
-				"int": "+1",
-				"wis": "+3"
-			},
-			"skill": {
-				"perception": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"resist": [
-				"bludgeoning"
-			],
-			"languages": [
-				"telepathy 30 ft. (empathy, bonded creatures only)"
-			],
-			"cr": "4",
-			"trait": [
-				{
-					"name": "Encourage Violence",
-					"entries": [
-						"The host of a hungry pennon has advantage on all attacks."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) piercing damage."
-					]
-				},
-				{
-					"name": "Aggressive Suggestion",
-					"entries": [
-						"As an action or bonus action, the hungry pennon attempts to convince its host to attack a target. This may be a potential opponent or something that is threatening the host, but it can just as easily be an arbitrary choice by the hungry pennon, such as a pack animal or random person in a village. The host can attempt a {@dc 13} Wisdom saving throw to resist this compulsion (if the host and pennon have been bonded for at least a month, this saving throw has disadvantage). Failure means the host attacks the targeted creature for at least one round. Each round after the first attack, the host can use their reaction to make another saving throw to try to overcome the hungry pennon's compulsion and stop attacking the target."
-					]
-				},
-				{
-					"name": "Psychic Bond",
-					"entries": [
-						"As an action or bonus action, the hungry pennon can telepathically offer to make a psychic bond with a potential host within 10 feet. The host perceives this as mental images of themselves and the hungry pennon being gloriously victorious in combat. The host must willingly accept this offer for the bond to form. Once the bond is formed, the pennon follows the host. A pennon never willingly leaves a bonded host.",
-						"To break this bond, the host must attack it and inflict enough damage to drive it away or convince it to choose a different host. The bonded host must succeed on a {@dc 13} Intelligence saving throw each time it wants to attack the pennon; failure means they cannot attack it that round. The host has disadvantage on this saving throw. After a month of being bonded, the host cannot willingly break the bond or attack the pennon."
-					]
-				},
-				{
-					"name": "Death Backlash",
-					"entries": [
-						"If a hungry pennon is killed and the host is within 60 feet, the host takes (17) {@damage 5d6} psychic damage."
-					]
-				},
-				{
-					"name": "Psychic Shriek {@recharge}",
-					"entries": [
-						"The hungry pennon assails a creature against a single target within 60 feet, dealing 17 ({@damage 5d6}) psychic damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"languageTags": [
-				"TP"
-			],
-			"damageTags": [
-				"P",
-				"Y"
-			],
-			"miscTags": [
-				"MW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Hungry pennons are strange beings that resemble a fleshy war banner that hangs freely in the air instead of being connected to a pole. It is large enough to engulf a human-sized creature, but its flat body only has the mass of a large child, most of which is in the form of its fleshy wings. The hungry pennon wants to feed, and it prefers to scavenge the bodies of freshly killed prey. However, a pennon is not an effective predator on its own, and can only bite with the tiny mouths hidden under its wings, so it relies on another creature to do its hunting for it.",
-							{
-								"type":"entries",
-								"name":"Symbiotic Bond",
-								"entries":[
-									"A hungry pennon psychically attaches itself to another creature, the more aggressive and intelligent the better. If a group of bandits, mercenaries, or vicious abhumans advances under a flapping standard of war that doesn’t actually seem to be connected to a pole, but rather hangs free-floating above one of the combatants, it’s probably not a flag but a hungry pennon. Thus, it drives its host (or hosts) into more frequent and more vicious conflicts. The creature to which a hungry pennon makes this attachment may at first value the advantages provided. But over time, the pennon gains mental ascendancy. If the host is killed, the hungry pennon may flap away, or it may proposition a new host in the area."
-						    ]
-			        },
-							{
-								"type":"inset",
-								"entries":[
-									{
-										"type":"quote",
-										"entries":[
-											"These creatures are found in many colors and patterns. Some have skin the color of yours, mine, or a human’s, but I have seen one with the grey skin of an orc, and heard of others with the red of a tiefling or the green of a lizardfolk. Likewise, they may have stripes, spots, or scales. I wonder, can they change willingly to match their host, or are they born one color and stay that way their entire lives?"
-										],
-										"by":"Elmande, elf mage and scholar"
-									}
-								]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Imusten Crawler",
-			"source": "AotA",
-			"page": 187,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 110,
-				"formula": "15d10 + 28"
-			},
-			"speed": {
-				"walk": 30,
-				"burrow": 10,
-				"climb": 30
-			},
-			"str": 17,
-			"dex": 12,
-			"con": 15,
-			"int": 8,
-			"wis": 12,
-			"cha": 12,
-			"save": {
-				"str": "+6",
-				"int": "+2"
-			},
-			"skill": {
-				"perception": "+4",
-				"stealth": "+4"
-			},
-			"senses": [
-				"darkvision 30 ft."
-			],
-			"passive": 14,
-			"resist": [
-				"piercing"
-			],
-			"languages": [
-				"telepathy 30 ft."
-			],
-			"cr": "6",
-			"trait": [
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The imusten crawler's attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}24 ({@damage 6d6 + 3}) piercing damage. The target must make a {@dc 15} Constitution saving throw against its poison, which targets the creature's lungs, filling them with a numbing gel which deals 14 ({@damage 4d6}) necrotic damage, or half as much damage on a successful save. If the target fails its save, it must continue to save each round or take damage again as their lungs continue to produce more gel. If the target's hit points reach 0, it begins to suffocate. Any successful saving throw in this process means the creature coughs up the accumulated gel and no longer takes damage or makes saving throws against the venom from that bite.",
-						"If the crawler chooses to poison the target's skin instead of their lungs, their skin produces a slightly different gel that numbs and preserves their flesh. If the damage from the venom gel reduces the target's hit points to 0, it becomes {@condition paralyzed} and {@condition unconscious}, but does not die, and remains this way indefinitely. Eventually the creature may starve to death, but the crawler usually eats its preserved prey before that.",
-						"Sometimes a creature whose lungs were {@condition poisoned} by the crawler's gel is infected with a disease that will slowly turn them into an imusten crawler. Only medical intervention (or the use of magic or numenera) can prevent this transformation."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"languageTags": [
-				"TP"
-			],
-			"damageTags": [
-				"N",
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "An imusten crawler is a horrific worm-like creature with a diamond- shaped head, its interior edges crusted with fangs and eyes. Its subtle venom causes its victims to secrete a numbing gel that not only holds them in place but also drowns them from the inside as their lungs fill with fluid. The creature is equally likely to attack by clinging to an overhanging structure and wind itself downward or erupting from a tunnel or vent in the earth.",
-							{
-								"type":"entries",
-								"name":"Preserver",
-								"entries":[
-									"An imusten crawler can direct its venom into a creature’s skin, which coats its target in a layer of gel that paralyzes and numbs the creature indefinitely, allowing it to store food until it becomes hungry. An area filled with this gel is a sure sign that a crawler has been using the space as a larder."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Mysterious Goals",
-								"entries":[
-									"Imusten crawlers are intelligent but secretive. They resist attempts by other creatures to learn more about them and their ultimate origin. They can’t speak, but they possess a low-level telepathic ability to communicate basic concepts."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Seskii Aversion",
-								"entries":[
-									"An imusten crawler has an inexplicable fear of {@footnote seskii||Seskii, page 233}. When a crawler is in the presence of a seskii, the seskii’s crystals light up, and the crawler breaks off its attack and wriggles away."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The discarded equipment of an Imusten crawler’s eaten prey sometimes contains valuables, including a few cyphers."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Jesanthum",
-			"source": "AotA",
-			"page": 188,
-			"size": "M",
-			"type": "plant",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 38,
-				"formula": "7d8 + 7"
-			},
-			"speed": {
-				"walk": 30,
-				"burrow": 10
-			},
-			"str": 15,
-			"dex": 12,
-			"con": 13,
-			"int": 14,
-			"wis": 11,
-			"cha": 13,
-			"skill": {
-				"perception": "+4",
-				"stealth": "+3"
-			},
-			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
-			],
-			"passive": 14,
-			"vulnerable": [
-				"fire"
-			],
-			"conditionImmune": [
-				"blinded",
-				"deafened"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Spore Reproduction",
-					"entries": [
-						"A creature that falls victim to a jesanthum's spore burst attack must succeed on an additional {@dc 13} Constitution saving throw once combat concludes, or the spores germinate in the PC's lungs and send a thick stalk up through their mouth and nostrils sometime during the next day or two. This asphyxiates and kills the victim unless desperate measures are taken, eventually creating the perfect source of nutrition for new jesanthum. Treat as a disease that kills the victim in {@dice 1d4} days."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Impaling Tongue",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d10 + 2}) piercing damage and a Large or smaller target is {@condition grappled} (escape {@dc 14}). Until this grapple ends, the target is {@condition restrained}, and the blight can't impale another target. The target automatically takes 7 ({@damage 1d10 + 2}) piercing damage each round."
-					]
-				},
-				{
-					"name": "Spore Burst {@recharge}",
-					"entries": [
-						"The jesanthum exhales poisonous gas in a 10-foot-radius sphere centered on it. Each living creature in that area must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} with uncontrollable coughing.",
-						"A victim can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
-					]
-				}
-			],
-			"senseTags": [
-				"B",
-				"D"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			"conditionInflict": [
-				"grappled",
-				"paralyzed",
-				"restrained"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A patch of wildflowers in the distance waves massive blooms of vivid purple in the breeze. The trembling flowers smell of baking bread and honeyed syrup, an odor so potent that many recall their own best memories of eating sweets.",
-							"When a bed of jesanthum flowers bend their brilliant heads to reveal a lapping tongue the color of blood, and the thick stems uproot to expose powerful {@footnote 5-foot-long carnivorous bodies|Jesanthum can be found almost anywhere sunlight reaches, usually in beds of three to five.} of raking claws and stabbing barbs, those sweet recollections are forever shattered. Before the Ancients vaults opened, no one had ever heard of jesanthum, but now they’re a common cautionary tale among travelers.",
-							{
-								"type":"entries",
-								"name":"Bouquet of Flowers",
-								"entries":[
-									"To appease an angry patron or provide a gift of special significance for someone the characters need a favor from in return, PCs are asked to collect {@footnote a planter of jesanthum|Jesanthum are pretty, nice-smelling plants— until they’re not, at which point they’re hungry predators that attempt to eat PCs who have come too close.}. However, they are not given any details beyond a bare description of the flower’s “pretty” blooms."
-						    ]
-			       	}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Jiraskar",
-			"source": "AotA",
-			"page": 189,
-			"size": "H",
-			"type": "monstrosity",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 168,
-				"formula": "16d12 + 64"
-			},
-			"speed": {
-				"walk": 50
-			},
-			"str": 22,
-			"dex": 16,
-			"con": 19,
-			"int": 7,
-			"wis": 14,
-			"cha": 12,
-			"skill": {
-				"perception": "+6",
-				"stealth": "+7"
-			},
-			"senses": [
-				"blindsight 90 ft."
-			],
-			"passive": 16,
-			"immune": [
-				"psychic"
-			],
-			"cr": "11",
-			"trait": [
-				{
-					"name": "Illusion Liberty",
-					"entries": [
-						"The jiraskar has advantage on saving throws to resist being {@condition charmed} or {@condition paralyzed}. In addition, it has advantage on saves against illusions, poison, and spells."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The jiraskar makes two bite attacks."
-					]
-				},
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}22 ({@damage 3d10 + 6}) piercing damage."
-					]
-				},
-				{
-					"name": "Tail Slap {@recharge 5}",
-					"entries": [
-						"The jiraskar's tail sweeps out in a 20 foot cone with savagery. Each creature in that area must make a {@dc 16} Dexterity saving throw, taking 66 ({@damage 12d10}) bludgeoning damage on a failed save, or half as much if successful."
-					]
-				},
-				{
-					"name": "Swallow",
-					"entries": [
-						"As a bonus action, the jiraskar swallows a creature that it has bitten twice this round. While swallowed, the target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the jiraskar, and it takes 21 ({@damage 6d6}) acid damage at the start of each of the jiraskar's turns. A jiraskar can have only one creature swallowed at a time.",
-						"If the jiraskar takes 30 damage or more on a single turn from the swallowed creature, the jiraskar must succeed on a {@dc 14} Constitution saving throw at the end of that turn or regurgitate the creature, which falls {@condition prone} in a space within 10 feet. If the jiarskar dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 15 feet of movement, exiting {@condition prone}."
-					]
-				}
-			],
-			"senseTags": [
-				"B"
-			],
-			"actionTags": [
-				"Multiattack",
-				"Swallow"
-			],
-			"damageTags": [
-				"A",
-				"B",
-				"P"
-			],
-			"miscTags": [
-				"MW",
-				"RCH"
-			],
-			"conditionInflict": [
-				"blinded",
-				"restrained"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Terror doesn’t even begin to describe it. The woods seem still. Quiet. At the risk of sounding cliché́, too quiet. Then there is a tremor. A rumbling. Far more quickly than you might expect (if you were smart enough to realize that the rumbling was the approach of a large beast), a terrible but beautiful shape emerges from the tall trees, a creature as colorful as a jungle flower but burgeoning with teeth and hunger and death. Your doom charges at you as though destiny guided its feet. The only mercy is that it ends as quickly as it began.",
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "I apologize. I have a natural inclination to find refuge among the trees, and I felt the jiraskar would have trouble pursuing us there. I had no way of knowing that one sweep of its tail would break through every mighty trunk and give it a clear opportunity to swallow you whole."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Apology accepted, if you help me find my healing potions in its guts, these acid burns really sting."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							},
-							{
-								"type":"entries",
-								"name":"Apex predators",
-								"entries":[
-									"Jiraskars’ {@footnote colorful bodies|Jiraskars might have started as normal lizards or birds that were quickly evolved and released by some inscrutable device of the Ancients.} have fleshy frills and only two functioning limbs: powerful legs that carry them at prey with great speed. They have poor (practically nonexistent) natural senses, but they have a mysterious capacity to perfectly sense their environment, instantly seeing through illusion, invisibility, and similar distractions as if their perceptions were based on something entirely different than—and superior to—other creatures. The huge beasts live only to hunt. And because most of their prey is small, they must kill continually to survive."
-						    ]
-			        },
-							{
-								"type":"inset",
-								"entries":[
-									"Despite its size, a jiraskar’s coloration and natural stealthiness mean it often can approach within 100 feet of potential prey before it is noticed (usually the tremors of its footfalls and the crashing of knocked-over terrain obstacles are what gives it away). By then it is often too late, as it can reach its target with a move or a quick dash if necessary."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Fierce Animals of the Wild",
-								"entries":[
-									"Jiraskars are extremely fast. They are animals and act as such. They charge in with a savage bite and don’t stop biting until the prey is dead or they are. Because jiraskars are so fast, an encounter with one can arise very quickly. And because they are so powerful, an encounter can also end very quickly."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Jurulisk",
-			"source": "AotA",
-			"page": 191,
-			"size": "L",
-			"type": "aberration",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 165,
-				"formula": "17d10 + 72"
-			},
-			"speed": {
-				"walk": 60
-			},
-			"str": 19,
-			"dex": 17,
-			"con": 18,
-			"int": 14,
-			"wis": 14,
-			"cha": 18,
-			"save": {
-				"dex": "+7",
-				"con": "+8",
-				"wis": "+6",
-				"cha": "+8"
-			},
-			"senses": [
-				"truesight 120 ft."
-			],
-			"passive": 12,
-			"resist": [
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks not made with silvered weapons"
-				}
-			],
-			"immune": [
-				"cold",
-				"poison"
-			],
-			"conditionImmune": [
-				"poisoned",
-				"charmed"
-			],
-			"cr": "12",
-			"trait": [
-				{
-					"name": "Incorporeal Movement",
-					"entries": [
-						"The jurulisk can move through other creatures and objects as if they were difficult terrain. It takes 5 ({@damage 1d10}) force damage if it ends its turn inside an object."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The jurulisk has advantage on saving throws against spells and other magical effects."
-					]
-				},
-				{
-					"name": "Magical Weapons",
-					"entries": [
-						"The jurulisk's weapon attacks (piercing chill touch) are treated as if magical."
-					]
-				},
-				{
-					"name": "Regeneration",
-					"entries": [
-						"The jurulisk regains 10 hit points at the start of its turn. If the jurulisk starts its turn with 0 hit points, it collapses into so many separate one-dimensional lines and regains 1 hit point per hour, until it reforms after a full day. While it is regenerating in this way, it can't take any other actions. (If the jurulisk falls to 0 hit points because its component matter is scattered across a distance of 120 feet or farther, perhaps due to an explosion, it does not regenerate.)"
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The jurulisk makes three piercing chill touch attacks."
-					]
-				},
-				{
-					"name": "Piercing Chill Touch",
-					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 25 ft. (it can stretch so as to extend a \"limb\" to stab at a foe up to 25 feet away), one target. {@h}9 ({@damage 1d10 + 4}) piercing damage, plus 13 ({@damage 3d8}) cold damage."
-					]
-				},
-				{
-					"name": "Object Draining Touch",
-					"entries": [
-						"Instead of a multiattack, a jurulisk makes a single piercing chill touch attack. If it hits, the Jurulisk targets an object carried by a creature; either a weapon, armor, or preferably, a device of the numenera. The touched object is drained and gains a permanent and cumulative -1 penalty, either to AC, to hit, or if a device that provides some other benefit, to associated checks. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed, as is a weapon reduced to-5."
-					]
-				}
-			],
-			"traitTags": [
-				"Incorporeal Movement",
-				"Magic Resistance",
-				"Regeneration"
-			],
-			"senseTags": [
-				"U"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"C",
-				"O",
-				"P"
-			],
-			"miscTags": [
-				"MW",
-				"RCH"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "The Ancients, with their strange activities and vast displays of power, tore literal holes in the fabric of the universe. Sometimes, these were very small. Nothing to worry about.",
-							"The jurulisk hails from inconceivable dimensions. When it comes to this world, it is a one-dimensional line, possessing only length (not even width, let alone depth), imperceptible and incapable of interacting in a meaningful way. Eventually, others come to this world. Over the aeons, the jurulisks find each other and bond to form two- and eventually three-dimensional forms in a way that is difficult to comprehend.",
-							"Finally able to interact with the three- dimensional world, the jurulisk seeks energy to fuel its new form. Once it absorbs a great deal of power from living creatures, the sun, or an artificial energy source, a jurulisk attempts to control its environment—usually by eliminating {@footnote other potential threats|If it is possible to communicate or interact with a jurulisk, the means have not been discovered yet, even using telepathy.}, which means all other creatures.",
-							{
-								"type":"entries",
-								"name":"Alive? Yes, But.",
-								"entries":[
-									"The jurulisk is a living creature, but it is not organic in any traditional sense, and neither is it mechanical. Its form constantly shifts, adapting to its needs at the moment, but always looking like what some have described as “the framework for an ‘actual’ creature.” A jurulisk fights to the “death,” although it might not be permanently dead or destroyed, for such concepts might not apply. The creature is far too alien to tell."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-				"name": "Kanthid",
-				"source": "AotA",
-				"page": 192,
-				"size": "M",
-				"type": "monstrosity",
-				"alignment": [
-					"N"
-				],
-				"ac": [
-					{
-						"ac": 15,
-						"from": [
-							"natural armor"
-						]
-					}
-				],
-				"hp": {
-					"average": 66,
-					"formula": "12d8 + 12"
-				},
-				"speed": {
-					"walk": 30
-				},
-				"str": 16,
-				"dex": 14,
-				"con": 13,
-				"int": 5,
-				"wis": 12,
-				"cha": 16,
-				"skill": {
-					"deception": "+5",
-					"stealth": "+4"
-				},
-				"senses": [
-					"blindsight 60 ft."
-				],
-				"passive": 11,
-				"immune": [
-					"poison"
-				],
-				"conditionImmune": [
-					"charmed",
-					"poisoned"
-				],
-				"languages": [
-						"none",
-						"(no smarter than clever animals, even the ones that colonized the bones of an intelligent creature)"
-				],
-				"cr": "3",
-				"trait": [
-					{
-						"name": "Magic Resistance",
-						"entries": [
-							"The kanthid has advantage on saving throws against spells and other magical effects."
-						]
-					}
-				],
-				"action": [
-					{
-						"name": "Multiattack",
-						"entries": [
-							"The kanthid bites twice."
-						]
-					},
-					{
-						"name": "Bite",
-						"entries": [
-							"{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}5 ({@damage 1d4 + 3}) piercing damage plus 3 ({@damage 1d6}) poison damage.",
-							"If one target takes poison damage from the kanthid three times, it must succeed on a {@dc 14} Constitution saving throw. If the saving throw fails by 5 or more, the creature is instantly {@condition paralyzed}. Otherwise, a creature that fails the save begins to become {@condition paralyzed} and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition paralyzed} on a failure or ending the effect on a success. The paralysis lasts for 10 minutes, or less if the kanthid takes its Colonize action."
-						]
-					},
-					{
-						"name": "Colonize",
-						"entries": [
-							"If allowed to do so without interruption, a kanthid lowers its body across a {@condition paralyzed} (or recently slain) creature, allowing its many ciliated mouths to feed. Each round a kanthid feeds in this fashion automatically deals Bite damage.",
-							"A kanthid that completely consumes a meal leaves behind a skeleton chunked with gore and several hard nodules of kanthid eggs fused to the bone."
-						]
-					}
-				],
-				"traitTags": [
-					"Magic Resistance"
-				],
-				"senseTags": [
-					"B"
-				],
-				"actionTags": [
-					"Multiattack"
-				],
-				"damageTags": [
-					"I",
-					"P"
-				],
-				"miscTags": [
-					"MW"
-				],
-				"conditionInflict": [
-					"paralyzed",
-					"restrained"
-				],
-				      "fluff":{
-					"entries":[
-						{
-							"type":"entries",
-							"entries":[
-				        "The sound of sandpaper on sandpaper scratches the air when a kanthid moves. Most kanthids are multilimbed creatures shaped vaguely like other beasts and creatures. {@footone Whatever its underlying shape|Breaking open a defeated kanthid reveals it to be a composite creature made of hundreds of smaller “polyps” (essentially, tentacles surrounding a mouth and digestive sac protected by a mineral encrustation) built on the skeleton of a dead animal}, the rough skin of a kanthid is a stony mineral whorled and studded with short spines. Here and there, openings in the stone reveal mouths ringed in writhing cilia.",
-								{
-									"type":"entries",
-									"name":"Speech Mimickers",
-									"entries":[
-										"Kanthids with biped, humanoid shapes sometimes speak, though they don’t make much sense. Streams of nonsense, rhymes, names, stories, and even snippets of song might emerge from two or three different cilia-ringed mouths at once. Though a talking kanthid seems to make little sense, there is a theme to its babble: everything a given kanthid says or sings were things once said or sung by a particular individual, one who’s been dead for a while."
-							    ]
-				        },
-								{
-								  "type": "insetReadaloud",
-								  "entries": [
-								    {
-								      "type":"quote",
-								      "entries":[
-								        "It knows what Jarin knew. Jarin’s been gone for years; I know he’s dead. But then the thing appeared at my window, whispering words of love and our old happiness. It’s not Jarin, I understand that. But I’m going down to meet it anyhow, out behind the wall where Jarin and I used to meet."
-								      ],
-								      "by":"Note left by Salara before she went missing"
-								    }
-								  ]
-								},
-								{
-									"type":"entries",
-									"name":"Walking Dead, Almost",
-									"entries":[
-										"A wizard wanted information that only a dead and buried colleague had. Knowing of the kanthid ability to evoke the memories of slain victims, she infected the graveyard where her colleague was interred. A few miscalculations and weeks later, the entire graveyard and associated village was infected with wandering kanthids. Now that wizard seeks help in locating the particular kanthid she wants to interrogate among those radiating out from the village, though she’s careful to keep secret her part in creating the infection in the first place."
-							    ]
-				        }
-						  ]
-				    }
-				  ]
-				}
-		},
-		{
-			"name": "Killist",
-			"source": "AotA",
-			"page": 193,
-			"size": "S",
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"killist"
-				]
-			},
-			"alignment": [
-				"C",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 12,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 21,
-				"formula": "5d6 + 4"
-			},
-			"speed": {
-				"walk": 30,
-				"swim": 40
-			},
-			"str": 13,
-			"dex": 11,
-			"con": 12,
-			"int": 8,
-			"wis": 13,
-			"cha": 9,
-			"skill": {
-				"stealth": "+4"
-			},
-			"senses": [
-				"darkvision 120 ft."
-			],
-			"passive": 15,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"poison"
-			],
-			"languages": [
-				"Killist",
-				"about half have learned a few words of Common"
-			],
-			"cr": "1/2",
-			"trait": [
-				{
-					"name": "Strength in Numbers",
-					"entries": [
-						"A killist gains advantage on attacks if it and its target are within 5 feet of another killist that isn't {@condition incapacitated}."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) piercing damage plus 3 ({@damage 1d6}) poison damage."
-					]
-				},
-				{
-					"name": "Claws",
-					"entries": [
-						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) slashing damage plus 3 ({@damage 1d6}) poison damage."
-					]
-				},
-				{
-					"name": "Shortbow",
-					"entries": [
-						"{@atk rw} {@hit 3} to hit, range 20/60 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage plus 3 ({@damage 1d6}) poison damage."
-					]
-				}
-			],
-			"senseTags": [
-				"SD"
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"I",
-				"P",
-				"S"
-			],
-			"miscTags": [
-				"MW",
-				"RNG",
-				"RW"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Clawed, greasy fingers. Smacking lips. Chattering, pointed teeth. Tiny, beady eyes. Shrill voice. A penchant for thievery, murder, traps, and deception. It is difficult to find some aspect of a killist that isn’t annoying, off-putting, or downright abhorrent. There is a saying: “If a killist is speaking, you are listening to lies.” Killisti can be intimidated by shows of obvious force and threats to their lives, but even as they are cowed, they are plotting a way to trick and betray you.",
-							"{@footnote Killisti are diminutive corrupt humanoids|Killisti leaders are typically older females who may be the mother or grandmother of their entire band (typically a challenge 3 creature in their own right). They are even more devious and cruel than the others and thus retain their positions of authority. In addition to the matriarch, kiillisti can be found in bands of six to twelve.}, possibly forcibly mutated by devices found in an Ancients’ cache. Their oily flesh is pale, their eyes are dark, and they have slits on the sides of their torso that are frequently mistaken for gills. These, in fact, provide access to their poison sacs, which are positioned perfectly for killisti to slide their claws into as a part of an attack.",
-							{
-								"type":"entries",
-								"name":"Malice against Humans",
-								"entries":[
-									"Killisti hate humanity with a passion and delight in murder and sadistic acts against the targets of their malice. (They regard other similarly proportioned species as foes, but not with the murderous rage with which they react to humans; possibly because their ancestors were once human.)"
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Ambushers and Poisoners",
-								"entries":[
-									"Killisti hate and fear a fair fight. They set ambushes and traps whenever possible. Traps usually consist of spiked pits, tripwires, or spine-filled nets. Any sharp points in their traps are poisoned. Most killisti carry long knives and crude bows. These weapons are always freshly envenomed from the poison-seeping slits in their sides.",
-									"A band of killisti might set up an ambush at a bridge or along a road. They might even “bait” that trap with one of their number pretending to be hurt or dead at the center of the ambush. Other killisti may live on the edges of civilized areas, stealing what they need and preying upon those weaker than themselves. For example, a town with an infestation of killisti might start to experience disappearances among children or the elderly."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Laak",
-			"source": "AotA",
-			"page": 194,
-			"size": "T",
-			"type": "beast",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				12
-			],
-			"hp": {
-				"average": 7,
-				"formula": "2d6"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 7,
-			"dex": 15,
-			"con": 11,
-			"int": 2,
-			"wis": 10,
-			"cha": 4,
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 10,
-			"immune": [
-				"poison"
-			],
-			"cr": "1/8",
-			"trait": [
-				{
-					"name": "Pack Tactics",
-					"entries": [
-						"Laaks have advantage on attacks against a creature if at least one other active laak is within 5 feet of the creature."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Poison Bite",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage, and the target must succeed on a {@dc 12} Constitution saving throw or take 5 ({@damage 1d10}) poison damage."
-					]
-				}
-			],
-			"traitTags": [
-				"Pack Tactics"
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"I",
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "If you see one laak, you know that at least ten more are hiding nearby, probably measuring their chances on taking you down if you’re out alone."
-							      ]
-							    }
-							  ]
-							},
-							"Laaks are small, green-skinned, poisonous reptiles that attack larger prey in small groups. They can leap with surprising speed and strength. Found almost everywhere Ancients’ caches are dug up, laaks can become a scourge as they spread farther. However, they avoid cold regions.",
-							{
-								"type":"entries",
-								"name":"Vicious Pets",
-								"entries":[
-									"A few industrious souls have captured young laaks and trained them as vicious pets and guardians. They can be frightened off by displays of power (such as fire, noise, and the like). Although laaks are ubiquitous and annoying, they are generally not a huge threat to PCs. However, an encounter with a powerful NPC foe who keeps a few laaks as pets could be more interesting and more dangerous."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Sensitive to Odor",
-								"entries":[
-									"Certain scents seem to draw laak attacks. For example, the scent of most dyes (textile, written words, even hair) seems to enrage them, while the smell of smoke can drive them away."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Latos",
-			"source": "AotA",
-			"page": 196,
-			"size": "G",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 22,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 498,
-				"formula": "26d20 + 225"
-			},
-			"speed": {
-				"walk": 60
-			},
-			"str": 30,
-			"dex": 10,
-			"con": 29,
-			"int": 18,
-			"wis": 15,
-			"cha": 23,
-			"save": {
-				"dex": "+7",
-				"con": "+16",
-				"wis": "+9"
-			},
-			"skill": {
-				"arcana": "+11",
-				"perception": "+16"
-			},
-			"senses": [
-				"blindsight 120 ft."
-			],
-			"passive": 26,
-			"immune": [
-				"fire",
-				"poison",
-				"psychic",
-				{
-					"immune": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks that aren't adamantine"
-				}
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"cr": "23",
-			"trait": [
-				{
-					"name": "Legendary Resistance (3/Day)",
-					"entries": [
-						"If the latos fails a saving throw, it can choose to succeed instead."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The latos has advantage on saving throws against spells and other magical effects."
-					]
-				},
-				{
-					"name": "Magic Weapons",
-					"entries": [
-						"The latos weapon attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The latos can use one of the three facets of its Mental Assault (if they are recharged). It then makes two attacks with its colossal fists."
-					]
-				},
-				{
-					"name": "Fist",
-					"entries": [
-						"{@atk mw} {@hit 17} to hit, reach 15 ft., one target. {@h}21 ({@damage 2d10 + 10}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Mental Assault",
-					"entries": [
-						"Whenever the latos uses Mental Assault, it chooses from one of the three following \"facets.\"",
-						{
-							"type": "list",
-							"style": "list-hang-notitle",
-							"items": [
-								{
-									"type": "item",
-									"name": "Wide Assault {@recharge 5}.",
-									"entries": [
-										"All creatures within a 1-mile- radius sphere centered on the latos must succeed on a {@dc 21} Wisdom saving throw or take 22 ({@damage 4d10}) psychic damage on a failed save, or half as much damage on a successful one."
-									]
-								},
-								{
-									"type": "item",
-									"name": "Massive Assault {@recharge 5}.",
-									"entries": [
-										"All creatures within a 60-foot- radius sphere centered on the latos must succeed on a {@dc 21} Wisdom saving throw or take 88 ({@damage 16d10}) psychic damage on a failed save, or half as much damage on a successful one."
-										]
-								},
-								{
-									"type": "item",
-									"name": "Dream Assault {@recharge}.",
-									"entries": [
-										"All creatures within a 1-mile- radius sphere centered on the latos must succeed on a {@dc 21} Wisdom saving throw or have their consciousnesses transferred to a limited artificial dimension where they wander in a dreamlike world. A single round in the real world seems like a full day to the victims.",
-										"A victim can be rescued only by an external source, such as a telepathic ally who journeys into their mind to find and retrieve them (perhaps combatting the dream-like phantoms that confront them).",
-										"A character who spends more than an apparent year in this dream state suffers the permanent loss of 1 point from their Intelligence score for each year. In addition, each apparent year, they must succeed on a {@dc 21} Wisdom save or lose their wits."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"legendary": [
-				{
-					"name": "Fist Attack",
-					"entries": [
-						"The latos makes one fist attack."
-					]
-				},
-				{
-					"name": "Teleport (Costs 2 Actions)",
-					"entries": [
-						"The latos teleports up to 500 feet to an unoccupied space it can see."
-					]
-				},
-				{
-					"name": "Recharge (Costs 3 Actions)",
-					"entries": [
-						"The latos automatically recharges one of the facets of its mental assault ability."
-					]
-				}
-			],
-			"traitTags": [
-				"Legendary Resistances",
-				"Magic Resistance",
-				"Magic Weapons"
-			],
-			"senseTags": [
-				"B"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"Y"
-			],
-			"miscTags": [
-				"MW",
-				"RCH"
-			],
-			      "fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-							{
-								"type":"inset",
-								"entries":[
-									{
-										"type":"quote",
-										"entries":[
-											"The civilizations that created the numenera have been gone for ages before my kind were part of this world. Even these caches and other remnants are just what they discarded and things that somehow survived great spans of time without failing. But the latos preserves within it an intact piece set aside by its creatures. To see such a thing, to walk among its creatures and constructions, would be like walking in the garden of the gods as they were creating worlds."
-										],
-										"by":"Elmande, elf mage and scholar"
-									}
-								]
-							},
-			        "Gigantic and mysterious, latoses are very rare, found only in the remotest areas. For some reason, the Ancients decided to preserve locations within small, artificially closed universes and hide them away inside massive guardians. The ways of the Ancients were strange indeed.",
-							"The 50-foot body of a latos is made of a unique alloy, and its head is a transparent sphere that contains an area far larger than its size would indicate. In this area, reflected in the “face” of the latos, is {@footnote a place of Anceint importance, permanently preserved and deserted|If the latos is destroyed, its body shatters and scatters across a mile radius. At the center of that area, the location stored in the sphere is transplanted as if it had always been there. It is perfectly preserved but empty of life (except perhaps for machine entities or creatures that were in stasis).}.",
-							{
-								"type":"entries",
-								"name":"Accessing What a Latos Guards.",
-								"entries":[
-									"No one has ever successfully spoken with a latos, but a character with telepathic abilities (or a device) might be able to establish a dialogue with one of these enigmatic creatures. If so, the PCs have a decent chance at negotiating a peaceful agreement, as latoses are not inherently aggressive, but they would have to work extremely hard to convince the latos to provide access to the location it protects. But should they manage such a feat, a latos can transport a willing target into the location stored in its sphere by touch."
-						    ]
-			        },
-							{
-								"type":"inset",
-								"entries":[
-									"The closed universe within a latos may be a place that explorers can reach through other means, such as dimensional travel. Navigating to such a location would be perilous and protected by other guardians and devices of the numenera. If explorers were able to reach it, the latos guarding that space would almost immediately become aware of the intrusion and either attack or attempt to eject the intruders."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"Aside from the transplanted location itself, scavengers picking through the artificial body of a destroyed latos will find {@dice 1d10 + 6} cyphers, {@dice 1d6} oddities, and one or two relics."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Margr",
-			"source": "AotA",
-			"page": 197,
-			"size": "M",
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"margr"
-				]
-			},
-			"alignment": [
-				"C",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 17,
-					"from": [
-						"{@item chain shirt|phb}",
-						"{@item shield|PHB}"
-					]
-				}
-			],
-			"hp": {
-				"average": 22,
-				"formula": "5d8"
-			},
-			"speed": {
-				"walk": {
-					"number": 30,
-					"condition": "actions"
-				}
-			},
-			"str": 11,
-			"dex": 14,
-			"con": 10,
-			"int": 10,
-			"wis": 8,
-			"cha": 8,
-			"skill": {
-				"athletics": "+4"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 9,
-			"languages": [
-				"Common",
-				"Margr"
-			],
-			"cr": "1",
-			"trait": [
-				{
-					"name": "Margr Cunning",
-					"entries": [
-						"The margr has advantage on Intelligence, Wisdom, and Charisma saving throws against trickery, lies, and illusion, including magic that attempts to do the same."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The margr makes two attacks with its spear. The second attack has disadvantage."
-					]
-				},
-				{
-					"name": "Spear",
-					"entries": [
-						"{@atk mw,rw} {@hit 4} to hit, reach 5 ft. or range 30/120 ft., one target. {@h}5 ({@damage 1d6 + 2}) piercing damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Parry",
-					"entries": [
-						"The margr adds 2 to its AC against one melee attack that would hit it. To do so, the margr must see the attacker and be wielding a melee weapon."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack",
-				"Parry"
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MW",
-				"RW",
-				"THW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "No two margr look alike, but most are around human-size and have some aspect of goat—a goat head, goat horns, goat legs, goat hooves, {@footnote or some combination or varying degrees thereof|Margr are likely some hybrid between human and animal, crafted by an unthinking numenera device in an accidental surge of flesh-fusing power.}. Margr live lives of terrible violence, killing each other (or really, anything they find) out of rage, sport, or lust. They breed and mature quickly, however, so their numbers never seem to diminish. {@footnote They travel in small bands led by the strongest and most savage|Margr chieftains can reach terrifying size. Some report the rare individual at 8 or 9 feet in height.}.",
-							{
-								"type":"entries",
-								"name":"Attired for Arocity",
-								"entries":[
-									"Margr wear trophies of their dead opponents but are poor crafters, so these displays are crude at best—severed heads on hooks, ears or fingers threaded on cords as necklaces, and so forth. This means that, on top of everything else, margr stink of rotting meat at all times."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Influenced from the Top",
-								"entries":[
-									"Margr are vicious and bloodthirsty. They are not smart, but they are crafty, making them difficult to fool. Killing their leader sends them into a frenzy of confusion and fear. In this situation, PCs could easily escape, but they could also intimidate the remaining margr into doing as they command. A very powerful and forceful character could become the new leader, but such a position would be challenged so frequently that it would make the margr poor followers overall."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Born Raiders",
-								"entries":[
-									"Margr harass civilized people on a regular basis, raiding villages or trade caravans. Some communities put bounties on their heads, hoping that mercenaries will eliminate the threat, but people not aware of margr origins often think of margr as creatures of supernatural evil—demons or devils—and do their best to hide from them. Thankfully, the nomadic margr usually move on after a few raids."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Mastigophore",
-			"source": "AotA",
-			"page": 198,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 14,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 61,
-				"formula": "9d8 + 21"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 20,
-			"dex": 12,
-			"con": 17,
-			"int": 14,
-			"wis": 12,
-			"cha": 7,
-			"skill": {
-				"perception": "+3"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 13,
-			"languages": [
-				"Mastigophore"
-			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Keen Sight and Smell",
-					"entries": [
-						"The mastigophore has advantage on Wisdom (Perception) checks that rely on sight or smell."
-					]
-				},
-				{
-					"name": "Self Destruction",
-					"entries": [
-						"When a mastigophore dies, it explodes on a 1-2 on 1d6. All creatures within 5 feet of it must succeed on a {@dc 14} Dexterity save or take {@damage 4d8} fire damage, or half that if successful."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The mastigophore makes two attacks: one with each of the barbed whips it extrudes from both hands."
-					]
-				},
-				{
-					"name": "Whip",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 15 ft., one creature. {@h}10 ({@damage 1d10 + 5}) piercing damage, and the target must succeed on a {@dc 14} Constitution saving throw or be {@condition stunned} during their next turn."
-					]
-				}
-			],
-			"traitTags": [
-				"Keen Senses"
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MW",
-				"RCH"
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Mastigophores are automatons that look human but {@footnote can instantly transform their hands into long, barbed whips whenever they wish|With a thought, mastigophores can extrude organic matter from their wrists in the form of long, barbed whips.}. When first encountered, {@footnote appear to be average, uniformed humans with a military stance|Mastigophores can take on the appearance of other humanoids, such as elves, or orcs, if they gain enough experience with such creatures.}. Quiet and excellent stalkers, they are encountered in one of two modes: on guard or hunting.",
-							"Mastigophores guard certain ancient ruins, complexes, or machines, usually in groups of two or more. They warn trespassers away once with unintelligible words (but obvious intentions), and if their warning is not heeded, they attack and fight without regard for their safety.",
-							{
-								"type":"entries",
-								"name":"Hungry Constructs.",
-								"entries":[
-									"Despite their machine-filled interiors, mastigophores need to consume organic material to function and create their weapons. Although they can subsist on plant matter, whoever created mastigophores designed them to enjoy hunting and killing animal prey. In this endeavor, they are very aggressive, and they act alone, leaving their “partners” behind to guard whatever it is they’re protecting."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Lost Language",
-								"entries":[
-									"Mastigophores speak, but not in any language known today. Stern and focused, they cannot be convinced to shirk their duties. However, if they are not hunting, and if the PCs don’t try to get past them while they are standing guard, mastigophores are not hostile."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Merkadian Soldier",
-			"source": "AotA",
-			"page": 198,
-			"size": "M",
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"merkadian soldier"
-				]
-			},
-			"alignment": [
-				"L",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 14,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 18,
-				"formula": "4d8"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 10,
-			"dex": 14,
-			"con": 10,
-			"int": 11,
-			"wis": 11,
-			"cha": 12,
-			"skill": {
-				"perception": "+2",
-				"stealth": "+4"
-			},
-			"senses": [
-				"darkvision 120 ft."
-			],
-			"passive": 12,
-			"languages": [
-				"Merkadian",
-				"any languages known by its host body"
-			],
-			"cr": "1/4",
-			"trait": [
-				{
-					"name": "Stealth Field {@recharge}",
-					"entries": [
-						"The soldier uses its action to become blurred, indistinct, and odorless for one minute. For the duration, the soldier gains advantage on stealth checks and creatures have disadvantage on attacks against the soldier, including against creatures with blindsight."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Longsword",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) piercing damage."
-					]
-				},
-				{
-					"name": "Detonation Lobber {@recharge 5}",
-					"entries": [
-						"Ranged Weapon Attack:",
-						"{@hit 4} to hit, range 30/120 ft., one target. {@h}5 ({@damage 1d6 + 2}) fire damage, and all targets within 10 feet must succeed on a {@dc 13} Dexterity saving throw or take the same damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Death Regeneration",
-					"entries": [
-						"If the soldier starts its turn with 0 hit points, it seems dead. However, it regains 1 hit point per hour, until it reforms after a full day unless its blade, which was fused with its hand, is separated by more than 30 feet. While it is regenerating in this way, it can't take any other actions."
-					]
-				}
-			],
-			"senseTags": [
-				"SD"
-			],
-			"damageTags": [
-				"F",
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "The stink of rotting flesh often precedes the appearance of a so-called Merkadian soldier. The soldier is never far behind its odor, moving with amazing alacrity for a humanoid that is otherwise apparently dead. Clutched in one hand is a sword crusted with all manner of the numenera. These vicious soldiers understand only destruction and war. They may respond to queries in the language of their host body, describing how they are soldiers of Grand Merkadia (a place that doesn’t exist, or at least one that hasn’t existed since the time of the Ancients). Particularly crafty negotiators might be able to form a short-lived alliance with a soldier.",
-							{
-								"type":"entries",
-								"name":"Alone or Part of a Platoon",
-								"entries":[
-									"Lone Merkadian soldiers can be found anywhere, usually looking for enemies to destroy or other platoon members. In rare instances, platoons of up to twenty-six Merkadian soldiers manage to assemble, at which time their tactics change from sneaking assassination to full frontal assault."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Almost Nerver-dying",
-								"entries":[
-									"A defeated Merkadian soldier often returns to life, though afterward it looks more corpselike than ever, and its eyes more hollowed-out. Clutched in one hand is a sword encrusted with all manner of the numenera, which could be the source of the soldier’s ability to return to the fight even after receiving mortal wounds."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"\"Cursed\" Blade",
-								"entries":[
-									"If a Merkadian soldier’s sword is taken as loot (treat it as a longsword), tiny machines, too small to be easily noticed, begin to move from it into the PC who claims the blade. The effect initially disfigures the character, causing raised metallic veins to appear all over their flesh. The contaminated item is obviously responsible for the infection, and if it is destroyed or abandoned, the infection subsides. The longer the PC keeps the contaminated item, the more their dreams Ware filled with imagery of a long-concluded war fought above the atmosphere, and the greater the chance that they don’t wake at all, except as {@footnote a reprogrammed Merkadian soldier pledged to fight in a dead conflict with no memory of any previous existence|There is little hope for a character fully changed into a Merkadian soldier, though anything is possible if the right machine of the Ancients is found.}."
-						    ]
-			        },
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "The transformation ability of a Merkadian soldier is perhaps the closest thing we have seen to necromancy in the numenera. I am not sure if this creature is best characterized as a lich, mummy, or some kind of revenant. Of course, as with most things in the numenera, our magical explanations are more for our contemporary convenience than accurate descriptions of a creature’s nature."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Mesomeme",
-			"source": "AotA",
-			"page": 201,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 144,
-				"formula": "17d10 + 51"
-			},
-			"speed": {
-				"walk": 30,
-				"swim": 30
-			},
-			"str": 18,
-			"dex": 15,
-			"con": 16,
-			"int": 6,
-			"wis": 13,
-			"cha": 15,
-			"skill": {
-				"deception": "+5",
-				"perception": "+4",
-				"stealth+5(whilemoving": "underwater)"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 14,
-			"cr": "6",
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The mesomeme makes two attacks: one with each of its two pincers once it rises from the water. If the mesomeme hits the same creature with both pincers as part of one Multiattack, the mesomeme can also use its sever head attack."
-					]
-				},
-				{
-					"name": "Pincers",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d6 + 4}) piercing damage."
-					]
-				},
-				{
-					"name": "Sever Head",
-					"entries": [
-						"The target must succeed on a {@dc 14} Constitution saving throw or drop to 0 hit points. At the beginning of its next turn, the target must succeed on a modified death saving throw. If successful, it regains 1 hit point and is {@condition restrained}.",
-						"If it fails, its head is severed by a pincer. The severed head is placed on a new tendril that rises up to impale it, which occurs as a separate reaction on the mesomeme's part.",
-						"Attacking a mesomeme's severed heads accomplishes nothing more than robbing the crustacean of long-term sustenance."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "When first encountered, a mesomeme often appears to be a number of individual creatures—people and animals—perhaps swimming or wading in shallow water. Each person is speaking, and the animals are making noises as well. It’s a strange choir of babble. Only on closer inspection does it become clear that the creatures are just severed heads mounted on slender, grey tendrils that are almost translucent. These tendrils sprout from holes in the chitinous shell of a massive crustacean with eight legs, two of which end in massive pincers.",
-							{
-								"type":"entries",
-								"name":"Façade of Intelligence",
-								"entries":[
-									"Façade of Intelligence. Despite the fact that the severed heads on the tendrils speak, the mesomeme cannot do so, nor can it understand speech. It is not very intelligent and acts on instinct. The mesomeme feeds on the mental activity of its victims, stimulating the brains in their severed heads, which remain preserved for weeks on its tendrils. {@footnote This stimulation causes the heads to speak or otherwise babble, growl, or squawk.|Sometimes a severed head says something so startling (perhaps coincidentally meaningful or relevant to one of the characters) that a PC is fooled into thinking that the mesomeme is sapient.}",
-									"At any given time, the mesomeme has 1d6 + 4 heads. If it dwells near civilization, half of the heads will be human, elves, dwarves, and so on, and the other half will be other types of creatures, such as orcs, goblins, large mammals or reptiles, or large birds."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Babblign Thing",
-								"entries":[
-									"A potential encounter with a mesomeme involves a small town being terrorized by a creature the locals call “the babbling thing” that lives in a nearby lake. However, some people instead claim that the lake is haunted by the recently dead, whose voices can still be heard echoing across the water. Either way, the residents would be eternally grateful to anyone who can rid them of the menace that makes it too dangerous to fish or get fresh water."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Mlox",
-			"source": "AotA",
-			"page": 203,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N",
-				"G"
-			],
-			"ac": [
-				12
-			],
-			"hp": {
-				"average": 66,
-				"formula": "12d8 + 12"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 16,
-			"dex": 14,
-			"con": 13,
-			"int": 14,
-			"wis": 12,
-			"cha": 16,
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 11,
-			"resist": [
-				{
-					"resist": [
-						"piercing  slashing"
-					],
-					"note": "from nonmagical attacks"
-				}
-			],
-			"immune": [
-				"poison",
-				"psychic"
-			],
-			"conditionImmune": [
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"Mlox",
-				"Common"
-			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Open Third Eye (Recharge After Short Rest)",
-					"entries": [
-						"The mlox uses their action to open their third eye. For 1 minute, the mlox can see in normal (and magical) darkness, see {@condition invisible} creatures and objects, automatically detect visual illusions and succeed on saving throws against them, and perceive the original form of a shapechanger or a creature that is otherwise transformed.",
-						"The mlox may also peer into neighboring planes of existence that impinge on their current reality.",
-						"In addition, the mlox can use open eye actions."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The mlox makes two shortsword attacks."
-					]
-				},
-				{
-					"name": "Shortsword",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) slashing damage."
-					]
-				},
-				{
-					"name": "Open Eye Actions",
-					"entries": [
-						"The mlox can take 1 open eye action, choosing from the options below. Only one open eye action option can be used at a time and only at the end of another creature's turn (though Eyeflash can be used during another creature's turn).",
-						"The mlox regains spent open eye actions at the start of its turn, while their third eye is open.",
-						{
-							"type": "list",
-							"style": "list-hang-notitle",
-							"items": [
-								{
-									"type": "item",
-									"name": "Shortsword",
-									"entries": [
-										"The mlox makes a shortsword attack."
-									]
-								},
-								{
-									"type": "item",
-									"name": "Eyebeam",
-									"entries": [
-										"The mlox fires a single beam of energy (from its third eye) at a foe within 120 feet that it can sense, dealing 7 ({@damage 2d6}) fire damage on a failed {@dc 13} Dexterity saving throw."
-									]
-								},
-								{
-									"type": "item",
-									"name": "Eyeflash",
-									"entries": [
-										"The mlox's third eye flashes, adding 2 to its AC against one melee attack that would hit it."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"F",
-				"S"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Only one thing distinguishes a human from a mlox, and it’s rarely obvious: a mlox can trigger a portion of its forehead to iris open, revealing a mechanical, glowing “third eye.” But mloxan are secretive, not given to revealing their odd anatomy, their history, or why they hide in human form. Mloxan are particularly suspicious of machine creatures and give them as wide a berth as possible, especially drones of {@footnote Peerless||Peerless, page 214}.",
-							{
-								"type":"entries",
-								"name":"Third Eye and Machine Brain",
-								"entries":[
-									"Most mloxan avoid conflict. If forced to fight, they do so with normal weapons and are slightly more robust than an average human, but nothing special—that is, until a mlox opens its third eye. When it does so, it makes a direct connection with the surrounding environment and gains several abilities.",
-									"If a mlox is slain and dissected, its third eye is revealed to be the leading edge of a mechanical brain that occupies the skull space normally filled by a biological one."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Hiding in Plain Sight",
-								"entries":[
-									"Mloxan try to be easy-going and agreeable because they don’t want to draw attention to themselves. If found out, a mlox will promise much to a PC in return for keeping its secret. Or, it may decide that the best way to ensure that a character stays quiet is to eliminate them, especially if they seem to be negotiating in bad faith. On the other hand, during some desperate moment, an NPC the characters assumed to be a regular person could open their third eye to resolve the situation, revealing a previously unknown ability, and potentially that the NPC is a mlox."
-								]
-			        },
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "We have no way of knowing how long the mloxan have been walking among us. The release of the numenera into the world again may have been the start of it, or they may have quietly slipped out of stasis and into our villages a long time ago. The ones I know of appear human, and are trustworthy folk, but there may be others who look like humans, dwarves, elves, or even vile creatures such as drow and orcs, and may have very different agendas that are yet to be revealed."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Murden",
-			"source": "AotA",
-			"page": 204,
-			"size": "M",
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"murden"
-				]
-			},
-			"alignment": [
-				"L",
-				"NX",
-				"C",
-				"NY",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"{@item leather armor|PHB}"
-					]
-				}
-			],
-			"hp": {
-				"average": 37,
-				"formula": "7d8 + 6"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 16,
-			"dex": 14,
-			"con": 12,
-			"int": 10,
-			"wis": 13,
-			"cha": 14,
-			"skill": {
-				"deception": "+4",
-				"persuasion": "+4",
-				"damageimmunities": "psychic"
-			},
-			"senses": [
-				"darkvision 30 ft."
-			],
-			"passive": 11,
-			"conditionImmune": [
-				"charmed",
-				"frightened"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Murden Cynicism",
-					"entries": [
-						"The murden has advantage on saving throws against being {@condition charmed} or {@condition frightened}."
-					]
-				},
-				{
-					"name": "Mental Hiss",
-					"entries": [
-						"Although inadvertent, the murden's inherent telepathic powers are irritating and harmful to nearby creatures, who perceive it as an annoying static that scrambles thought. When a creature starts its turn within 30 feet of a murden who is not {@condition incapacitated}, the creature must succeed on a {@dc 14} Wisdom saving throw or gain disadvantage on all attacks, saves, and checks, which persists until it moves more than 30 feet from the murden."
-					]
-				},
-				{
-					"name": "Poison Weapon",
-					"entries": [
-						"If the murden has a moment to prepare, such as when preparing an ambush, it poisons its blade. The first hit with the blade that deals damage also requires that the target succeed on a {@dc 14} Constitution saving throw or take 7 ({@damage 2d6}) poison damage in addition to the weapon's normal damage."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The murden makes two attacks, either with its scimitar-like blade or its sling. When possible, they attack from the shadows with ambushes and hit-and-run tactics.",
-						"They normally flee in the face of real danger."
-					]
-				},
-				{
-					"name": "Scimitar",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) slashing damage."
-					]
-				},
-				{
-					"name": "Sling",
-					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 150/600 ft., one target. {@h}2 ({@damage 1d4 + 2}) bludgeoning damage."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"B",
-				"I",
-				"S"
-			],
-			"miscTags": [
-				"MW",
-				"RNG",
-				"RW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-							{
-								"type": "insetReadaloud",
-								"entries": [
-									{
-										"type":"quote",
-										"entries":[
-											"Those who have experienced a murden’s telepathic white noise firsthand report that strange voices and long-forgotten memories sometimes arise in the mental interference in haunting and disturbing ways."
-										]
-									}
-								]
-							},
-			        "Murdens walk upright but would never be mistaken for humans. Backs hunched dramatically forward, skin covered in shiny black down, huge black eyes perched above a sharp, dirty yellow beak— {@footnote these things seem almost like enormous ravens with spindly arms rather than wings|Murden claim to originate in a parallel plane of existence, one not previously accessible until the first Ancients’ cache opened.}. Tattered leather cloaks cover their backs, and many carry a leather bag or wear one on a strap to hold the various objects they have collected.",
-							{
-								"type":"entries",
-								"name":"Voiceless Schemers",
-								"entries":[
-									"Murdens don’t speak. They communicate with one another telepathically. However, their telepathy annoys other intelligent creatures. The presence of a living murden fills the minds of nearby creatures with a sort of mental hiss. Add this irritation to their paranoid mindset, their cruelty, their selfishness, and their duplicitous, scheming nature, and there is little to like about a murden.",
-									"Those who have experienced a murden’s telepathic white noise firsthand report that strange voices and long-forgotten memories sometimes arise in the mental interference in haunting and disturbing ways.",
-									"Communicating with murdens is very difficult, but they seem to understand at least a little of other languages they come across and can convey information through gestures or drawings in the sand. Trusting them, however, is a fool’s mistake, for a murden delights in lies and trickery for their own sake."
-						    ]
-			        },
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Many wonders of the Ancients I’ve preferred to these murden. Their bright eyes, their tools, and their use of the numenera indicate intelligence, but they don’t speak. Their features put me in mind of crows, though I’ve always found crows pleasant. These creatures troubled me. The harmony of my thoughts, normally so comforting, grows more scrambled the closer I approach."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Then don’t approach."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Nalurus",
-			"source": "AotA",
-			"page": 206,
-			"size": "M",
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"usually human"
-				]
-			},
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 14,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 52,
-				"formula": "8d8 + 16"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 16,
-			"dex": 11,
-			"con": 15,
-			"int": 12,
-			"wis": 11,
-			"cha": 7,
-			"passive": 10,
-			"languages": [
-				"Common",
-				"or whatever language they spoke before infection"
-			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Brain-liquifying Reaction",
-					"entries": [
-						"If a creature starts its turn within 30 feet of the nalurus and the victim can see the nalurus's face, the creature must succeed on a {@dc 12} Constitution saving throw, or they suffer a massive headache and begin to drip pink froth from their nose; they have disadvantage on all checks, saves, and attacks. The victim must repeat the saving throw at the end of their next turn. On a success, the effect ends and the victim escapes with only 14 ({@damage 4d6}) necrotic damage. On a failure, the creature's brain completely liquifies, killing it.",
-						"A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the nalurus's face until the start of its next turn, when it can avert its eyes again. If it looks at the nalurus in the meantime, it must immediately make the save.",
-						"A nalurus is immune to seeing itself in a mirror; it already survived the information plague that rendered it simply as a carrier."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Staff",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) bludgeoning damage."
-					]
-				}
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"B",
-				"N"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "t wasn’t pretty. I found them lying dead in puddles of pink slime. Looked as if they’d vomited their brains out."
-							      ],
-							      "by":"Bystander"
-							    }
-							  ]
-							},
-							"A nalurus always wears a hood or mask. It may be pretending, even to itself, that it’s still human, despite the terrible infection it survived but still carries. The nalurus transmits its infection by sight. {@footnote If a humanoid sees a nalurus without its hood and looks full upon the disquieting lines, spirals, and geometric shapes laid out in ridges across the creature’s face|A slain nalurus remains as dangerous to look upon as a live one for about one day, after which the ridges slump and rot, making the corpse’s head merely ugly and dead as opposed to lethal and dead.}, the awful pattern imprints on the victim’s mind. Something in the interplay of information, refraction, and the physical structure of the victim’s brain sets off a cruel and rapid chain reaction. What begins as a pinkish nose drip ends when the victim’s brain completely liquefies and exits the victim’s head from the eyes, nose, mouth, and ears less than a minute after the infection occurs.",
-							{
-								"type":"entries",
-								"name":"Solitude Seekers",
-								"entries":[
-									"A nalurus seeks solitude, but over time, that very solitude can drive the creature to take risks with the safety of others by seeking out their company. A nalurus that remains alone for too long can go insane, becoming {@footnote a paranoid murderer that shows off its face at the first opportunity|The nalurus doesn’t have to be aware of a victim to affect it. A nalurus can be incapacitated or even dead (for up to one day) and still affect humanoids who see its face with its Brain-liquifying Reaction.}. A nalurus that hasn’t gone insane from loneliness is usually angry at being disturbed, discourteously blunt, and quick to send visitors on their way. A kind act or gift can soften the creature’s manner, but doesn’t change things."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Eccentric Old Hermit",
-								"entries":[
-									"The PCs are asked to deal with a man at the edge of town who has started stealing food and scaring the children. Most people in the community are apprehensive about the recluse because of stories of a decades-old plague that only he survived."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Nevajin",
-			"source": "AotA",
-			"page": 207,
-			"size": "M",
-			"type": "monstrosity",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				18
-			],
-			"hp": {
-				"average": 32,
-				"formula": "5d8 + 10"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 14,
-			"dex": 14,
-			"con": 14,
-			"int": 15,
-			"wis": 14,
-			"cha": 11,
-			"save": {
-				"dex": "+2",
-				"con": "+4",
-				"wis": "+2",
-				"cha": "+2"
-			},
-			"skill": {
-				"arcana": "+4",
-				"perception": "+2"
-			},
-			"senses": [
-				"blindsight 10 ft.",
-				"darkvision 60 ft."
-			],
-			"passive": 12,
-			"immune": [
-				"fire",
-				"lightning"
-			],
-			"languages": [
-				"Common",
-				"various others"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Device Use",
-					"entries": [
-						"A nevajin always has a couple of offensive and defensive devices concealed about its body. Those advantages are already figured into the nevajin's stat block. However, a nevajin may also have a one-use cypher that allows it to turn {@condition invisible} or teleport up to 500 ft. away to escape attack, which it uses if its split ability fails to save at least one part of it."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Lightning Ray",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, range 120 ft., one target. {@h}20 ({@damage 3d10 + 2}) lightning damage."
-					]
-				}
-			],
-			"reaction": [
-				{
-					"name": "Split",
-					"entries": [
-						"The nevajin splits its head from its body after taking damage it feels is egregious (half or more of its total), becoming two creatures: a hovering head and a headless body. Both have effectively the same stats as a single nevajin, except the head has a fly speed of 60 feet (hover). One attempts to flee, while the other provides a distraction.",
-						"Usually, it's the head that flies away."
-					]
-				}
-			],
-			"senseTags": [
-				"B",
-				"D"
-			],
-			"languageTags": [
-				"C"
-			],
-			"damageTags": [
-				"L"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "The nevajin is not a single creature, but two. It looks like a stocky, bent-over humanoid or a crouching predatory beast with a misshapen, almost skull-like head. But the head is actually a separate creature that adheres to the main body by means of connecting filaments and telekinetic force. When joined, the two portions infuse each other with filaments that allow an exchange of information and nutrients. Separation is a painful process that the nevajin does not undertake lightly. Both portions of the nevajin have their own brains, sensory organs, and digestive systems.",
-							{
-								"type":"entries",
-								"name":"Curious Specimen",
-								"entries":[
-									"Nevajin do not appear to age, and their method of reproduction is a mystery. The nevajin might be asexual, with each portion budding at the same time to create a new joined creature. But as weird as these creatures are, they seem to find the world in which they find themselves even more curious. They are constantly seeking new information and experiences."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Purveyors of Knowledge",
-								"entries":[
-									"Nevajin are fairly intelligent and speak many languages in their harsh, whispery voices. Nevajin are sources of information and interesting relics of the past. When a secret bit of knowledge is needed, the PCs must travel deep into the wilderness to find the nevajin that possesses it. They can provide a great deal of information about the numenera, but they expect to be paid for their secrets, usually in the form of items, or new information."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Neveri",
-			"source": "AotA",
-			"page": 208,
-			"size": "H",
-			"type": "monstrosity",
-			"alignment": [
-				"C",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 16,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 175,
-				"formula": "17d12 + 64"
-			},
-			"speed": {
-				"walk": {
-					"number": 50,
-					"condition": "(hover)"
-				}
-			},
-			"str": 24,
-			"dex": 17,
-			"con": 18,
-			"int": 9,
-			"wis": 14,
-			"cha": 12,
-			"senses": [
-				"blindsight 90 ft."
-			],
-			"passive": 16,
-			"resist": [
-				"acid",
-				"cold",
-				"fire",
-				"lightning",
-				"thunder",
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks"
-				}
-			],
-			"immune": [
-				"necrotic",
-				"poison"
-			],
-			"languages": [
-				"picks up new languages telepathically"
-			],
-			"cr": "11",
-			"trait": [
-				{
-					"name": "Regeneration",
-					"entries": [
-						"The neveri regains 10 hit points at the start of its turn. If it starts its turn with 0 hit points, it continues to regenerate, but does not take an action during the turn it started at 0."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The neveri makes two tendril attacks."
-					]
-				},
-				{
-					"name": "Tendril",
-					"entries": [
-						"{@atk mw} {@hit 11} to hit, reach 5 ft., one Large or smaller creature. {@h}29 ({@damage 4d10 + 7}) bludgeoning damage and the target is {@condition grappled} (escape {@dc 17}), and is {@condition restrained} until this grapple ends. A neveri can grapple up to two",
-						"Medium (or smaller) or one Large creature at one time."
-					]
-				},
-				{
-					"name": "Attack Organs {@recharge 5}",
-					"entries": [
-						"The neveri creates a transient, specialized organ that sprays acid, spits a flesh-rotting enzyme, or generates a burst of electricity. Treat as a line effect 60 feet long and 5 feet wide. Each creature in that line must make a {@dc 16} Dexterity saving throw, taking 66 ({@damage 12d10}) damage (either acid, necrotic, or lightning) on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Engulf",
-					"entries": [
-						"The neveri attempts to engulf a {@condition grappled} target, who must succeed on a {@dc 16} Strength saving throw, or be engulfed, ending the grapple. While engulfed, the target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the neveri, and it takes 21 ({@damage 6d6}) acid damage at the start of each of the neveri's turns. A neveri can have only one creature swallowed at a time.",
-						"If the neveri takes 30 damage or more on a single turn from the swallowed creature, the neveri must succeed on a {@dc 14} Constitution saving throw at the end of that turn or regurgitate the creature, which falls {@condition prone} in a space within 10 feet of the neveri. If the neveri starts a turn with 0 hit points, a swallowed creature is no longer {@condition restrained} by it and can escape from the temporary corpse by using 15 feet of movement, exiting {@condition prone}."
-					]
-				}
-			],
-			"traitTags": [
-				"Regeneration"
-			],
-			"senseTags": [
-				"B"
-			],
-			"actionTags": [
-				"Multiattack",
-				"Swallow"
-			],
-			"damageTags": [
-				"A",
-				"B"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"blinded",
-				"grappled",
-				"restrained"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "A neveri is a floating blob of heaving, writhing flesh, 15 feet in diameter, apparently rotting and always oozing pus, dark fluids, and the odor of a thousand graves. A neveri constantly extrudes new sections of skin, mouths, eyes, spines, clawed hands, and whipping tendrils, seemingly force-grown from the mass of dead matter that serves as the nucleus of its body.",
-							{
-								"type":"entries",
-								"name":"",
-								"entries":[
-									"Neveri were secured by the Ancients in various forgotten prisons. But why? Why didn’t the Ancients simply destroy the neveri? Many possibilities suggest themselves, but the plainest answer might be because {@footonte even the Ancients could not devise a method to kill them.|The only way to stop a neveri is by confining it or shunting it into an ultimate region of destruction, such as the sun}",
-									"Thankfully extremely rare, neveri apparently spend years at a time either inactive or imprisoned from some earlier epoch. When one becomes active (or escapes), it makes a lair in a hard-to-reach location within a day or two of a large population of living things and sets to work feeding its ravenous appetite."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Aware",
-								"entries":[
-									"A neveri has a low-level telepathic ability that allows it to sense when living creatures come near and perhaps pick up bits of the thinking creature’s language. It responds to attempts at communication by forming a mouth that issues horrifying threats. Then it attacks."
-								]
-							},
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "When the gods—or as in this case, the Ancients—imprison a powerful evil thing rather than destroy it, I always wonder why. I’ve developed several possible reasons:",
-											"• Death would release the slain thing to reincarnate at an unknown time and place;",
-											"• Moral reluctance;",
-											"• The thing’s potential use as a weapon;",
-											"• The thing is linked with its imprisoners, so that to slay one slays both;",
-											"• Death would be too easy; the jailors want the thing eternally punished;",
-											"• Or, as is apparently the case for the neveri, it’s impossible for the thing to actually die"
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Ojj",
-			"source": "AotA",
-			"page": 210,
-			"size": "L",
-			"type": "elemental",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				17
-			],
-			"hp": {
-				"average": 375,
-				"formula": "30d10 + 210"
-			},
-			"speed": {
-				"walk": 30,
-				"fly": {
-					"number": 30,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 15,
-			"dex": 15,
-			"con": 25,
-			"int": 25,
-			"wis": 20,
-			"cha": 20,
-			"save": {
-				"int": "+15",
-				"wis": "+13",
-				"cha": "+13"
-			},
-			"skill": {
-				"deception": "+13",
-				"intimidation": "+13",
-				"perception": "+13"
-			},
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 23,
-			"resist": [
-				"acid",
-				"bludgeoning",
-				"cold",
-				"fire",
-				"lightning",
-				"necrotic",
-				"piercing",
-				"psychic",
-				"radiant",
-				"slashing",
-				"thunder"
-			],
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"poisoned",
-				"prone"
-			],
-			"languages": [
-				"telepathy 1 mile"
-			],
-			"cr": "25",
-			"trait": [
-				{
-					"name": "Energy Form",
-					"entries": [
-						"The ojj can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the ojj or hits it with a melee attack while within 5 feet of it takes 10 ({@damage 2d10}) psychic damage. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes 5 ({@damage 1d10}) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
-					]
-				},
-				{
-					"name": "Mind Sense",
-					"entries": [
-						"An ojj automatically senses the presence of all minds within its telepathy range unless the minds are behind a force field."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The ojj fires two psychic blasts, uses two unique abilities, or one psychic blast and one unique ability."
-					]
-				},
-				{
-					"name": "Psychic Blast",
-					"entries": [
-						"{@atk rw} {@hit 15} to hit, range 100/200 ft., one target. {@h}62 ({@damage 10d10 + 7}) force damage or 51 ({@damage 8d10 + 7}) psychic damage."
-					]
-				},
-				{
-					"name": "Unique Abilities",
-					"entries": [
-						"Ojj have advanced psychic powers. Each ojj usually has four of the following abilities, and may have one additional ability unique to that individual.",
-						"Unless otherwise stated, these abilities require a direct line of sight to the target. Effects listed here that duplicate spells are nonmagical numenera psychic abilities. If the effect would normally have a saving throw, it is a {@dc 21} Wisdom save.",
-						"• {@spell Dominate monster}, except limited to a 500-foot range. Depending on the ojj, a controlled target can attempt to break free every round, every minute, every hour, every day, or every few days. This control usually manifests as a visible colored halo around the head of the target.",
-						"• {@spell Detect thoughts}, except affecting up to five creatures within 60 feet.",
-						"• Deal 2 ({@damage 1d4}) psychic damage to a creature within 500 feet, even if it has no direct line of sight to that creature.",
-						"• {@spell Telekinesis}, except the weight limit is 200 pounds and the range is 60 feet. If the ojj uses its action doing nothing but telekinesis, it can move up to 400 pounds.",
-						"• Create a vaguely humanoid {@footnote psychic construct|Psychic Construct. Use stats for basic automaton type five.|Basic automaton, page 246}, an automaton made of pure mental energy, that lasts for one minute. The construct obeys the ojj's mental commands and can manipulate physical objects as well as a human can.",
-						"• Increase its AC by +2 until the start of its next turn.",
-						"• Activate, deactivate, or manipulate a numenera device within 60 feet.",
-						"• Drain energy from a numenera relic, installation, or vehicle within 60 feet, restoring 30 hp if uncommon, 50 hp if rare, 75 hp if very rare, or 90 hp if it is legendary. The object must make a depletion roll each time an ojj uses this ability on it.",
-						"• {@spell Imprisonment} (slumber) on a creature within 60 feet, lasting 1 minute.",
-						"• {@spell Wall of force}, except it is a 10-foot square, within 60 feet, lasting 1 minute.",
-						"• {@spell Fabricate}, affecting a 5-foot cube within 60 feet; the ojj can use this ability to perform fine crafting over time, even numenera crafting, given the proper materials.",
-						"• {@spell Major Image}, with the nearest edge within 10 feet, lasting 10 minutes.",
-						"• Alter its psychic blast to deal cold, fire, lightning, radiant, or thunder damage instead of psychic damage.",
-						"• Heal 10 points of damage to a creature other than itself within 60 feet.",
-						"• {@spell Teleport} itself and up to three other Medium creatures up to 1 mile away."
-					]
-				},
-				{
-					"name": "Unique Augmentations",
-					"entries": [
-						"Instead of one of the above abilities, an ojj might have one of the following augmentations to one of its abilities:",
-						"• The ability's range increases by one category (60 feet to 100 feet, 100 feet to 500 feet, 500 feet to 1 mile, 1 mile to 5 miles). This doesn't affect the sight requirements for the ability.",
-						"• The ability can affect targets that aren't within the ojj's line of sight. This doesn't affect the range of the ability.",
-						"• The ability can be used once per round without counting toward the normal limitation of two abilities per action."
-					]
-				}
-			],
-			"senseTags": [
-				"D"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"languageTags": [
-				"TP"
-			],
-			"damageTags": [
-				"F",
-				"O",
-				"Y",
-				"R",
-				"C",
-				"L",
-				"T"
-			],
-			"miscTags": [
-				"AOE",
-				"RW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Ojj are powerful energy beings left over from the ancient past. Most were imprisoned and buried long ago by advanced numenera-wielding civilizations that couldn’t quite destroy them. These hateful things have been silently fuming for aeons, but a few have picked at the locks of their cages long enough to allow them limited access to the outer world, which they use to lure beings with lies, threats, and promises of great rewards in exchange for their freedom.",
-							{
-								"type":"entries",
-								"name":"Advanced Telepaths",
-								"entries":[
-									"Ojj are naturally telepathic and can mentally communicate to a range of about 1 mile, even speaking simultaneously to dozens or hundreds of people."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Malevolent",
-								"entries":[
-									"Ojj enjoy dominating others, inflicting pain, and flattery. They act as if they are gods and expect weaker beings to worship them. They place little value on the lives of physical beings and act only in the interest of their power and ego. They are very dangerous foes and can cause a lot of destruction if allowed to move freely. An imprisoned or weakened one might present itself as a god to a cult or tribe of humanoids, demanding sacrifices and torture in its name."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage",
-								"entries":[
-									"The afterimages of an ojj’s death might coalesce into {@dice 1d6} energy- based cyphers and one or two energy-based relics. The numenera that imprisoned a now-dead ojj can also be salvaged for {@dice 1d6} additional cyphers."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Oorgolian Soldier",
-			"source": "AotA",
-			"page": 212,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 16,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 45,
-				"formula": "6d10 + 12"
-			},
-			"speed": {
-				"walk": 50
-			},
-			"str": 15,
-			"dex": 12,
-			"con": 13,
-			"int": 14,
-			"wis": 11,
-			"cha": 13,
-			"skill": {
-				"athletics": "+6",
-				"perception": "+2"
-			},
-			"passive": 13,
-			"immune": [
-				"poison",
-				"psychic"
-			],
-			"vulnerable": [
-				"thunder"
-			],
-			"conditionImmune": [
-				"blinded",
-				"charmed",
-				"deafened",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"Oorgolian"
-			],
-			"cr": "2",
-			"trait": [
-				{
-					"name": "Self-detonation",
-					"entries": [
-						"When the soldier dies, it explodes as if the center of one its own detonation thrower attacks. This destroys the built-in, back-mounted detonation thrower, and on a roll of 1-2 on {@dice 1d6}, also destroys the slug-thrower relic."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Oorgolian Slug Thrower",
-					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 120 ft., one target. {@h}13 ({@damage 2d10 + 2}) piercing damage."
-					]
-				},
-				{
-					"name": "Detonation Thrower {@recharge 5}",
-					"entries": [
-						"The soldier deploys a back-mounted device that hurls a detonation up to 120 feet.",
-						"Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 11} Dexterity saving throw or take 21 ({@damage 6d6}) fire damage on a failed save, or half as much damage on a successful one."
-					]
-				}
-			],
-			"damageTags": [
-				"F",
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"RW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Another wonder fashioned by the Ancients, the mechanical entities known as Oorgolian soldiers patrol isolated areas for reasons unknown, possibly anticipating another cache of the Ancients appearing nearby. They are almost always found in groups of five or seven. Lanky and alien in their movements, these quasi-humanoid automatons stand almost 8 feet tall. They wield a variety of weapons.",
-							{
-								"type":"entries",
-								"name":"Motivations Lost to Time",
-								"entries":[
-									"No one knows the origin of the word “Oorgolian.” It is thought to be a term from a tongue used by the Ancients, and so now long dead. On their own, Oorgolians act on prior orders that literally may be a million years old or more, so their actions and motives don’t always make sense. Sometimes they completely ignore creatures they find. Sometimes they attempt to communicate in their own language. Sometimes they ambush and attack."
-						    ]
-			        },
-							{
-								"type":"inset",
-								"entries":[
-									"Oorgolians act on prior orders that literally may be a million years old or more, so their actions and motives don’t always make sense."
-								]
-							},
-							{
-								"type":"entries",
-								"name":"Potential Allies",
-								"entries":[
-									"At least one mercenary leader, with the help of those who’d made a study of arcana of the Ancients, has captured and repurposed a number of Oorgolian soldiers, probably using sound. These soldiers remember nothing of their former duties and work for their new masters."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Powerful Treasure (Salvage)",
-								"entries":[
-									"Oorgolian soldiers carry relic weapons called Oorgolian slug throwers. In addition, each Oorgolian body contains {@dice 1d6} cyphers."
-						    ]
-			        },
-							{
-								"type": "insetReadaloud",
-								"entries": [
-									{
-										"type":"quote",
-										"entries":[
-											"These are soldiers after my own heart. Maybe they don’t know what they’re fighting for anymore. Maybe what they’re fighting for is long dead! But they fight anyway. And look at their discipline! Still patrolling, still training, still maintaining their weapons. If I’d had a company like this back in the day, my clan would never have lost the Delve..."
-										],
-										"by":"Faim Trubeard, dwarf veteran and prospector"
-									}
-								]
-							},
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "I’m sorry that memory brings you such pain, Faim. But take comfort. These Oorgolians would have likely refused to help, or worse, taken the Delve for their own"
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Peerless",
-			"isNamedCreature": true,
-			"source": "AotA",
-			"page": 214,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 75,
-				"formula": "10d8 + 30"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 18,
-			"dex": 11,
-			"con": 16,
-			"int": 12,
-			"wis": 10,
-			"cha": 14,
-			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 120 ft."
-			],
-			"passive": 13,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"blinded",
-				"charmed",
-				"deafened",
-				"frightened",
-				"paralyzed",
-				"petrified",
-				"poisoned"
-			],
-			"languages": [
-				"telepathy 120 ft. (only with other machines)",
-				"can quickly learn most verbal languages"
-			],
-			"cr": "5",
-			"trait": [
-				{
-					"name": "Machine Focused",
-					"entries": [
-						"When Peerless uses Inveigle or Spawn New",
-						"Instance, constructs and machines have disadvantage on their saves; all other creatures have advantage."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"Peerless has advantage on saving throws against spells and other magical effects."
-					]
-				},
-				{
-					"name": "Magic Weapons",
-					"entries": [
-						"Peerless's weapon attacks are treated as if magical."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"Peerless makes two claws attacks."
-					]
-				},
-				{
-					"name": "Claws",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d4 + 4}) slashing damage."
-					]
-				},
-				{
-					"name": "Inveigle",
-					"entries": [
-						"One creature within 60 feet must succeed on a {@dc 13} Wisdom saving throw or be {@condition charmed} by Peerless for 1 hour or until Peerless does something harmful to them. The {@condition charmed} creature is friendly and helpful to Peerless, but after the effect ends, they know that their inclinations were manipulated."
-					]
-				},
-				{
-					"name": "Spawn New Instance {@recharge}",
-					"entries": [
-						"One creature chosen by Peerless within 30 feet that is currently or has previously succumbed to Inveigle must succeed on a {@dc 13} Constitution saving throw or be infected with a machine disease called Peerless. While infected, the target can't regain hit points, and its hit point maximum is reduced by 10 ({@dice 3d6}) every 24 hours. If the target is a living creature, during this period their biological parts are observed to be slowly replaced by machine components. If the disease reduces the target's hit point maximum to 0, the target instantly transforms into another instance of Peerless. If the disease is halted before it goes to completion, a biological creature's body rejects the artificial parts, and regains maximum hit points at the same rate they were lost."
-					]
-				}
-			],
-			"traitTags": [
-				"Magic Resistance",
-				"Magic Weapons"
-			],
-			"senseTags": [
-				"B",
-				"SD"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"languageTags": [
-				"TP"
-			],
-			"damageTags": [
-				"S"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"charmed"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			        "Peerless is a machine creature that exists in multiple construct bodies, sometimes {@footnote taking over other machines to duplicate more versions of itself, erasing any personality or goals that may have previous existed|A cypher or relic the PC carries with the potential to host even a limited machine intelligence might be briefly infected with Peerless. It begins to speak as Peerless and work against the PC however it can for a day, after which the instance of Peerless, finding the item too small to hold it, erases itself.}. All it cares about is spreading itself as far and wide as possible. It is Peerless.",
-							{
-								"type":"entries",
-								"name":"Fearless Narcissist",
-								"entries":[
-									"Those have encountered instances of Peerless describe the construct as bloodthirsty, single-minded, and a bit unstable; each individual construct claims that it is Peerless, the source mind from which all others are made. Even newly converted machines and constructs say the same. This begs the question of where the originating intelligence of Peerless actually resides—maybe in a hidden ruin, as a consciousness in some nearby but unseen dimension, or as a mind distributed across every connected construct."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Prejudiced Against Flesh",
-								"entries":[
-									"An individual Peerless construct ignores biological creatures if there are constructs or machines to be interacted with. However, if there is no choice but to interact with a living creature, Peerless may establish verbal communication. In such cases, it comes across as over-the-top pompous and self-important, always refering to itself as Peerless. Although Peerless isn’t worried about risking any particular instance of itself in combat, it will forgo conflict in return for information about the location of other machines, especially {@creature mlox|aota|mloxan}. However, if a PC happens to be part machine, all bets are off, because Peerless will be keen to convert them. (Purely biological creatures may face the same issue, though only if Peerless is feeling experimental.)"
-						    ]
-			        },
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "The arrogance is what astonishes me most. And the lack of need for someone other than itself, only and forever. Having no one else to interact with would drive most creatures mad. Though perhaps that is exactly what happened, aeons ago."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Philethis",
-			"source": "AotA",
-			"page": 217,
-			"size": "M",
-			"type": "aberration",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 146,
-				"formula": "17d8 + 72"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 16,
-			"dex": 16,
-			"con": 18,
-			"int": 18,
-			"wis": 15,
-			"cha": 19,
-			"skill": {
-				"perception": "+7",
-				"stealth": "+8"
-			},
-			"senses": [
-				"truesight 120 ft."
-			],
-			"passive": 17,
-			"resist": [
-				"cold",
-				"fire",
-				"lightning",
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks"
-				}
-			],
-			"immune": [
-				"poison",
-				"psychic"
-			],
-			"conditionImmune": [
-				"charmed",
-				"frightened",
-				"poisoned"
-			],
-			"languages": [
-				"any it encounters"
-			],
-			"cr": "13",
-			"trait": [
-				{
-					"name": "Legendary Resistance (3/Day)",
-					"entries": [
-						"If the philethis fails a saving throw, it can choose to succeed instead."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The philethis has advantage on saving throws against spells and other magical effects."
-					]
-				},
-				{
-					"name": "Magic Weapons",
-					"entries": [
-						"The philethis' weapon attacks are treated as if magical."
-					]
-				},
-				{
-					"name": "New Instance",
-					"entries": [
-						"A destroyed philethis reforms elsewhere in {@dice 2d6} days, regaining all its hit points and becoming active again.",
-						"The new body appears inside a previously keyed machine of the Ancients."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The philethis can use its Stare of the Aeons, and make three {@condition invisible} force blade attacks."
-					]
-				},
-				{
-					"name": "Invisible Force Blade",
-					"entries": [
-						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d10 + 3}) slashing damage."
-					]
-				},
-				{
-					"name": "Stare of the Aeons",
-					"entries": [
-						"The philethis focuses on one creature it can see within 30 feet of it. Whether or not the target can see the philethis, the target must succeed on a {@dc 17} Wisdom saving throw or be {@condition stunned} until the end of the philethis' next turn. If the target's saving throw is successful, the target is immune to the philethis' stare for the next 24 hours."
-					]
-				},
-				{
-					"name": "Teleport",
-					"entries": [
-						"The philethis teleports, along with any equipment it is wearing or carrying, up to 500 feet to an unoccupied space it can see."
-					]
-				}
-			],
-			"legendary": [
-				{
-					"name": "Invisible Force Blade",
-					"entries": [
-						"The philethis makes an {@condition invisible} force blade attack."
-					]
-				},
-				{
-					"name": "Teleport (Costs 2 Actions)",
-					"entries": [
-						"The philethis uses a teleport action."
-					]
-				},
-				{
-					"name": "Stare of the Aeons (Costs 3 actions)",
-					"entries": [
-						"The philethis makes a",
-						"Stare of the Aeons attack."
-					]
-				}
-			],
-			"traitTags": [
-				"Legendary Resistances",
-				"Magic Resistance",
-				"Magic Weapons"
-			],
-			"senseTags": [
-				"U"
-			],
-			"actionTags": [
-				"Multiattack",
-				"Teleport"
-			],
-			"damageTags": [
-				"S"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			              "Of all the strange creatures that appeared in conjunction with the caches of the Ancients opening, few are more mysterious than philethis. It’s not even known for sure if they come from the caches, or if they were simply attracted to the event from somewhere else entirely. Some even wonder if they are not Ancients themselves, as all seem to have a far greater mastery of numenera than anything else.",
-										"No one has seen the entire body of a philethis and reported what they saw, but the glimpses noted to date suggest a biomechanical hybrid form. Typically what is seen is a metal and glass “face” surrounded by voluminous cloaks.",
-							{
-								"type":"entries",
-								"name":"Mysterious",
-								"entries":[
-									"Other speculation about the philethis includes claims that they are constructs, that they are demons, that they are tiny dimensions unto themselves, and/or that their “face” is actually a viewport for a creature beyond space and time. Most theories about their nature don’t even guess at what their goals or motivations might be. {@footnote They appear when and where they want to, and they usually seem to observe events from a distance |Something unexpected and unpredictable might happen when the philethis is near. The event should be small, but result in a significant change. For example, the PC slips and falls into a 10-foot-deep pit, suffering damage, but then finds something of great interest at the bottom.} (although another theory suggests that they influence the events somehow)."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Mysterious",
-								"entries":[
-									"Philethis are not hostile (though aggressively defend themselves if attacked). If engaged in conversation, they might respond in their strange, machinelike voices, speaking in the native language of whomever they talk to. However, such interchanges usually make a philethis more enigmatic rather than less. Their explanations for things rarely make sense, and the questions they ask seem unrelated to anything going on around them. A typical philethis interaction might go as follows:",
-									{
-										"type":"quote",
-										"entries":[
-											"Human: Who are you and what are you doing here?",
-											"Philethis: The moon is full, and the roses will bloom in 437 hours.",
-											"Human: What are you talking about?",
-											"Philethis: When you were eleven years old and playing with that ball, why did you bounce it three times against the wall but four times against the ground?",
-											"Human: How do you know anything about when I was a child?",
-											"Philethis: The galaxies will collide soon. We must prepare."
-										]
-									}
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Always One Step Ahead",
-								"entries":[
-									"Philethis are meant to be an enigma. Players (and their characters) should never fully understand the creatures, and if they believe that they do, something should happen to show that they are wrong. Moreover, the PCs should find out at odd times and in odd ways that the philethis are involved—or at least appear to be involved—in surprising situations. Are they just observing, or are they manipulating events somehow? And if so, why? The quest for this knowledge could be the basis for an entire campaign."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Plasmar",
-			"source": "AotA",
-			"page": 218,
-			"size": "M",
-			"type": "elemental",
-			"alignment": [
-				"N"
-			],
-			"ac": [
-				{
-					"ac": 15,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 85,
-				"formula": "11d8 + 36"
-			},
-			"speed": {
-				"walk": 30
-			},
-			"str": 11,
-			"dex": 12,
-			"con": 12,
-			"int": 19,
-			"wis": 17,
-			"cha": 17,
-			"senses": [
-				"darkvision 60 ft."
-			],
-			"passive": 10,
-			"resist": [
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical attacks"
-				}
-			],
-			"immune": [
-				"fire",
-				"poison"
-			],
-			"conditionImmune": [
-				"exhaustion",
-				"grappled",
-				"paralyzed",
-				"petrified",
-				"poisoned",
-				"prone",
-				"restrained",
-				"unconscious"
-			],
-			"languages": [
-				"Plasmar"
-			],
-			"cr": "7",
-			"trait": [
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The plasmar has advantage on saving throws against spells and other magical effects."
-					]
-				},
-				{
-					"name": "Plasma Form",
-					"entries": [
-						"A creature that touches the plasmar or hits it with a melee attack while within 5 feet of it takes 5 ({@damage 1d10}) fire damage and 5 ({@damage 1d10}) lightning damage, and catches fire; until someone takes an action to douse the fire, the creature takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
-					]
-				},
-				{
-					"name": "Regeneration",
-					"entries": [
-						"The plasmar regains 10 hit points at the start of its turn, {@footnote if on its home turf, which is typically near (within 500 feet) of some potent energy source|In areas of particularly strong energy fields (strong enough to possibly hurt regular creatures), plasmar might regenerate even more hit points per round and double or triple their maximum hit points.}. If it starts its turn with 0 hit points, it doesn't regenerate."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Touch",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one creature. {@h}15 ({@dice 2d10 + 4}) fire (half) and lightning (half) damage. Targets must succeed on a {@dc 15} Constitution saving throw or be {@condition stunned} until the end of their next turn. Finally, the target catches fire; until someone takes an action to douse the fire, the creature takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
-					]
-				},
-				{
-					"name": "Welding Touch",
-					"entries": [
-						"{@atk mw} {@hit 7} to hit, reach 5 ft., one {@condition stunned} humanoid. {@h}28 ({@damage 5d10}) fire damage plus 28 ({@damage 5d10}) lightning damage."
-					]
-				},
-				{
-					"name": "Plasma Blast {@recharge 5}",
-					"entries": [
-						"The plasmar emits plasma (fire and lightning) in a 100-foot-long, 5-foot-wide line. Each creature in that area must succeed on a {@dc 15} Dexterity saving throw or take 13 ({@damage 2d8 + 4}) fire damage plus 13 ({@dice 2d8} +",
-						"4) lightning damage and be {@condition stunned} until it succeeds on a saving throw at the end of each of its turns. Finally, the target catches fire; until someone takes an action to douse the fire; the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
-					]
-				},
-				{
-					"name": "Ride the Lightning {@recharge 5}",
-					"entries": [
-						"The plasmar becomes a bolt of lightning, along with any equipment it is wearing or carrying, and teleports up to 120 feet to an unoccupied space it can see."
-					]
-				}
-			],
-			"traitTags": [
-				"Magic Resistance",
-				"Regeneration"
-			],
-			"senseTags": [
-				"D"
-			],
-			"damageTags": [
-				"F",
-				"L"
-			],
-			"miscTags": [
-				"MW"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			              "Plasmars are tall, night-black humanoids swaddled in magnetic skins of luminous “liquid fire.” They’re intelligent entities drawn to areas where immense energies are generated or have been recently discharged. They dwell in subterranean tunnels around active volcanoes and in areas rich in Ancients machines that generate the sort of energy fields plasmars depend on to survive. {@footnote Sometimes plasmar scouting parties travel with thunderstorms, looking for new territory.| Plasmars are self-willed and can be strongly territorial, especially if they believe that visitors risk disrupting their energy fields}",
-							{
-								"type":"inset",
-								"entries":[
-											"Plasmars are not automatically hostile, though they are wary of visitors. Their speech is interspersed with the buzzing and snapping of electrical discharges."
-									]
-							},
-							{
-								"type":"entries",
-								"name":"Manifestations of a Sun",
-								"entries":[
-									"Plasmars are not automatically hostile, though they are wary of visitors. Their speech is interspersed with the buzzing and snapping of electrical discharges. Plasmars view the world differently than regular living creatures do, since they need energy the way that other creatures need air. According to plasmar lore, they originally lived on the surface of a sun that is now long dead and gone."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Storm-tossed Squatters",
-								"entries":[
-									"A group of plasmars materialized in the aftermath of a recent storm of noteworthy ferocity. The storm is long gone, but the plasmars remain on the crown of a bare hill not far away. A scholar who recently identified the hill as the site of an Ancient’s cache seeks mercenaries to eliminate the “black-cloaked squatters” that are preventing her from exploiting her discovery."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Salvage: Gift of Storm",
-								"entries":[
-									"Sometimes plasmars give a plasma detonation cypher as a gift."
-						    ]
-			        }
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Progenitor",
-			"source": "AotA",
-			"page": 221,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-				"N",
-				"E"
-			],
-			"ac": [
-				{
-					"ac": 16,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 126,
-				"formula": "11d10 + 66"
-			},
-			"speed": {
-				"walk": 20,
-				"swim": 40
-			},
-			"str": 25,
-			"dex": 11,
-			"con": 22,
-			"int": 10,
-			"wis": 13,
-			"cha": 9,
-			"skill": {
-				"perception": "+5"
-			},
-			"senses": [
-				"blindsight 120 ft.",
-				"darkvision 120 ft."
-			],
-			"passive": 15,
-			"resist": [
-				"bludgeoning",
-				"cold"
-			],
-			"languages": [
-				"telepathy 500 ft. (among progenitors and its young)"
-			],
-			"cr": "9",
-			"trait": [
-				{
-					"name": "Water Breathing",
-					"entries": [
-						"The progenitor can breathe only underwater."
-					]
-				},
-				{
-					"name": "Water Predator",
-					"entries": [
-						"The progenitor has advantage on Dexterity (Stealth) checks made to hide in water."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The progenitor can use Mothering and makes two claw attacks."
-					]
-				},
-				{
-					"name": "Claw",
-					"entries": [
-						"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}35 ({@damage 8d6 + 7}) slashing damage."
-					]
-				},
-				{
-					"name": "Mothering",
-					"entries": [
-						"The progenitor targets one creature it can sense within 30 feet of it. The target must succeed on a {@dc 18} Constitution saving throw or take 3 ({@damage 1d6}) psychic damage and then be affected either by fear or calm love, depending on what the progenitor chooses.",
-						"If filled with fear, the target becomes {@condition frightened} for 1 minute. An affected target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the progenitor's fear for the next 24 hours.",
-						"If filled with calm love, the target is {@condition charmed}, and moves toward the progenitor with open arms, all defenses lowered on their next turn. The progenitor's next two Claw attacks against the affected target automatically succeed and inflict maximum damage. This ends the calm love effect, and the creature is immune to the progenitor's calm love for the next 24 hours."
-					]
-				},
-				{
-					"name": "Eggburst",
-					"entries": [
-						"The progenitor's young hatch from her belly pouch, swarming all foes in a 20-foot-radius sphere centered on the progenitor with progenitor larva. Targets in the area must succeed on a {@dc 18} Constitution saving throw or take 45 ({@damage 10d8}) piercing damage, or half that if successful. Afterward, a {@creature progenitor larva swarm|aota} remains."
-					]
-				}
-			],
-			"traitTags": [
-				"Water Breathing"
-			],
-			"senseTags": [
-				"B",
-				"SD"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"languageTags": [
-				"TP"
-			],
-			"damageTags": [
-				"P",
-				"S",
-				"Y"
-			],
-			"miscTags": [
-				"AOE",
-				"MW"
-			],
-			"conditionInflict": [
-				"charmed",
-				"frightened"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-			              "These mermaid-like broodmares hate and fear surface-dwellers, seeing them as wholly alien and incomprehensible. Their life’s goal is to give birth to their young—creatures much like electric eels—and then protect those young from all dangers. Growing to more than 10 feet in height, progenitors look humanlike from a distance. Up close, even through murky water, it is clear that they are dangerous predators—and that’s even before they show their true colors.",
-							{
-								"type": "insetReadaloud",
-								"entries": [
-									{
-										"type":"quote",
-										"entries":[
-											"Mermaids? That’s a stretch.”"
-										],
-										"by":"Faim Trubeard, dwarf veteran and prospector"
-									}
-								]
-							},
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "I didn’t say they were mermaids. They remind me of mermaids. Certainly, I don’t need to enumerate the similarities? But yes, obviously there are many differences, too. Such as the fact that these progenitors are an order of magnitude older than anything that lives in our seas."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-								"type":"inset",
-								"entries":[
-									"Although the progenitors are tough physical combatants, their real challenge is their field of psychic energy. They can use this to affect the emotions of nearby creatures. The progenitor either fills them with fear, or fills them with calm love. Progenitors can be dangerous foes, even against large groups of PCs. They are scary creatures to encounter in any undersea adventure, especially in deep water where they are more likely to have larva swarms around them."
-								]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Progenitor Larva Swarm",
-			"source": "AotA",
-			"page": 221,
-			"size": "M",
-			"type": {
-				"type": "monstrosity",
-				"swarmSize": "T"
-			},
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				12
-			],
-			"hp": {
-				"average": 22,
-				"formula": "5d8"
-			},
-			"speed": {
-				"swim": 30
-			},
-			"str": 5,
-			"dex": 15,
-			"con": 10,
-			"int": 2,
-			"wis": 12,
-			"cha": 4,
-			"senses": [
-				"blindsight 60 ft.",
-				"darkvision 60 ft."
-			],
-			"passive": 11,
-			"resist": [
-				"bludgeoning",
-				"piercing",
-				"slashing"
-			],
-			"conditionImmune": [
-				"charmed",
-				"frightened",
-				"grappled",
-				"paralyzed",
-				"petrified",
-				"prone",
-				"restrained",
-				"stunned"
-			],
-			"cr": "1/4",
-			"trait": [
-				{
-					"name": "Swarm",
-					"entries": [
-						"The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny eel. The swarm can't regain hit points or gain temporary hit points."
-					]
-				},
-				{
-					"name": "Water Breathing",
-					"entries": [
-						"The larva swarm can only breathe underwater."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Bite",
-					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 0 ft., one creature in the swarm's space. {@h}5 ({@damage 2d4}) piercing damage."
-					]
-				}
-			],
-			"traitTags": [
-				"Water Breathing"
-			],
-			"senseTags": [
-				"B",
-				"D"
-			],
-			"damageTags": [
-				"P"
-			],
-			"miscTags": [
-				"MW"
-			]
-		},
-		{
-			"name": "Pygmy Hapax",
-			"source": "AotA",
-			"page": 222,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 13,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"average": 81,
-				"formula": "9d10 + 32"
-			},
-			"speed": {
-				"walk": 0,
-				"fly": {
-					"number": 60,
-					"condition": "(hover)"
-				},
-				"canHover": true
-			},
-			"str": 16,
-			"dex": 12,
-			"con": 19,
-			"int": 1,
-			"wis": 12,
-			"skill": {
-				"perception": "+3"
-			},
-			"senses": [
-				"blindsight 120 ft."
-			],
-			"passive": 13,
-			"immune": [
-				"poison"
-			],
-			"conditionImmune": [
-				"poisoned"
-			],
-			"cr": "3",
-			"trait": [
-				{
-					"name": "Keen Smell",
-					"entries": [
-						"The pygmy hapax has advantage on Wisdom (Perception) checks that rely on smell."
-					]
-				},
-				{
-					"name": "Color Burst",
-					"entries": [
-						"When a pygmy hapax dies, it explodes in a maelstrom of clashing colors. All creatures in a 20-foot-radius sphere centered on it must succeed on {@dc 13} Dexterity save or take 18 ({@damage 4d8}) necrotic damage, or half that if successful. In the aftermath, 3 ({@dice 1d6}) objects carried by creatures in the blast\u2014or potentially some portion of their anatomy\u2014takes on a bright new hue, possibly even dimly glowing."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The pygmy hapax makes two tendril attacks."
-					]
-				},
-				{
-					"name": "Tendrils",
-					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 10 ft., one target. {@h}10 ({@damage 2d6 + 3}) piercing damage and the target is {@condition grappled} (escape {@dc 13}; each failed escape attempt further entangles victim, cumulatively increasing escape DC by 1).",
-						"Until this grapple ends, the target is {@condition restrained}, and the pygmy hapax can't use its tendrils on another target. In addition, each round the grapple persists, the color of one object in their possession\u2014or some portion of their anatomy if it carries no unaffected objects\u2014turns black, starting with the brightest. Whether object or anatomy, this deals 10 ({@damage 3d6}) necrotic damage to the {@condition grappled} victim."
-					]
-				}
-			],
-			"traitTags": [
-				"Keen Senses"
-			],
-			"senseTags": [
-				"B"
-			],
-			"actionTags": [
-				"Multiattack"
-			],
-			"damageTags": [
-				"N",
-				"P"
-			],
-			"miscTags": [
-				"AOE",
-				"MW",
-				"RCH"
-			],
-			"conditionInflict": [
-				"grappled",
-				"restrained"
-			],
-			"fluff":{
-				"entries":[
-					{
-						"type":"entries",
-						"entries":[
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "They came down in great, long streams",
-											"as if settling to the earth in waves of dreams",
-											"I reached to touch one, just one, it seems",
-											"And oh the screams, the screams, the screams"
-							      ],
-							      "by":"Poet unknown (and not very good)"
-							    }
-							  ]
-							},
-							"No one can dispute the beauty of the pygmy hapax—at least, no one who has seen the brightly hued, floating creatures coming down to rest upon the earth, their trailing plumages following their descent. They are encountered either soaring in the sky or hovering, always at least a foot above the ground. Pygmy hapax tend to travel in large groups called clouds.",
-							{
-								"type":"entries",
-								"name":"Tendrils of Beauty and Threat",
-								"entries":[
-									"The tendrils are their true beauty—and their true danger. Each tendril trails nearly 20 feet or longer, and each is covered with millions of small, hollow barbs. Anything that falls into the hapax’s wake—or is purposefully snatched by a billowing tendril—quickly finds itself wrapped into oblivion, its very colors pulled from it as if by a great siphon."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Chromatic Variation Through Diet",
-								"entries":[
-									"The hapax’s complex color variations come directly from their food source, meaning that the creatures can change color right before your eyes if they’ve recently digested something. Pygmy hapax are always in search of the brightest hues, for those with the most saturated and complex color schemes are more likely to attract a mate."
-						    ]
-			        },
-							{
-								"type":"entries",
-								"name":"Hapax Lures",
-								"entries":[
-									"Pygmy hapax are attracted to brightly colored objects that move and sometimes can be called down from the sky with a proper hapax trap. They might also simply be attracted to colorful creatures that congregate. For instance, a large fight with an animal as bright as a {@creature jiraskar|aota} could draw a cloud of hapax."
-						    ]
-			        },
-							{
-							  "type":"inset",
-							  "entries":[
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Why do they call them pygmy hapax? Where are the regular-sized ones, and how large and bright are they? I question where the lore granted us by the quotien is anything other than an ancient puzzle designed to stymie rather than clarify."
-							      ],
-							      "by":"Elmande, elf mage and scholar"
-							    }
-							  ]
-							},
-							{
-							  "type": "insetReadaloud",
-							  "entries": [
-							    {
-							      "type":"quote",
-							      "entries":[
-							        "Let’s move away a little, why don’t we? I think they’re pretty, but I don’t like the look of those tendrils. And look, see those branches they were caught on? I don’t think they were glowing blue before."
-							      ],
-							      "by":"Faim Trubeard, dwarf veteran and prospector"
-							    }
-							  ]
-							}
-					  ]
-			    }
-			  ]
-			}
-		},
-		{
-			"name": "Tetrahydra",
-			"source": "AotA",
-			"page": 237,
-			"size": "M",
-			"type": "beast",
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 14,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 33,
-			  "formula": "6d8 + 6"
-			},
-			"speed": {
-			  "walk": 20,
-			  "fly": 120
-			},
-			"str": 17,
-			"dex": 11,
-			"con": 13,
-			"int": 5,
-			"wis": 13,
-			"cha": 6,
-			"senses": [
-			  "darkvision 60 ft."
-			],
-			"passive": 11,
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The tetrahydra can attack twice, once with its beak and once with its tentacles."
-				]
-			  },
-			  {
-				"name": "Beak",
-				"entries": [
-				  "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) slashing damage."
-				]
-			  },
-			  {
-				"name": "Tentacles",
-				"entries": [
-				  "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d6}) bludgeoning damage. If the target is a Medium or smaller creature, it is {@condition grappled} (escape {@dc 13}).",
-				  "Until this grapple ends, the tetrahydra automatically squeezes the target for 3 ({@damage 1d6}) bludgeoning damage each round and attacks the {@condition grappled} target twice with its beak, and it has advantage on attack rolls to do so."
-				]
-			  }
-			],
-			"senseTags": [
-			  "D"
-			],
-			"actionTags": [
-			  "Multiattack",
-			  "Tentacles"
-			],
-			"damageTags": [
-			  "B",
-			  "S"
-			],
-			"miscTags": [
-			  "MW"
-			],
-			"cr": "2",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "quote",
-					  "entries": [
-						"\"The tetrahydra is clearly a creature of bizarre standing, as it has no feet. Perhaps it stays aloft eternally or lands upon its great beaks to rest.\""
-					  ],
-					  "by": "Unknown"
-					},
-					"These large creatures, approximately 6 feet tall, look like black-feathered tetrahedrons with beaks and big wings. Tetrahydras have four tentacles that they keep coiled along their lower half. The tentacles uncoil and can be used as feet and weapons.",
-					{
-					  "type": "entries",
-					  "name": "Nest Protectors. ",
-					  "entries": [
-						"Tetrahydras fight to protect their eggs, which take two years to hatch and are situated in large nests as high up as the creatures can build them. Sometimes they attack alone, but more often they attack in groups of three or more. PCs are likely to run afoul of tetrahydras only if they disturb a nest. However, an NPC skilled in breaking animals to training could have a covey of them serving as attack beasts."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Thuman",
-			"source": "AotA",
-			"page": 238,
-			"size": "M",
-			"type": {
-			  "type": "humanoid",
-			  "tags": [
-				"thuman"
-			  ]
-			},
-			"alignment": [
-			  "N"
-			],
-			"ac": [
-			  10
-			],
-			"hp": {
-			  "average": 13,
-			  "formula": "2d8 + 4"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 13,
-			"dex": 10,
-			"con": 15,
-			"int": 7,
-			"wis": 12,
-			"cha": 14,
-			"senses": [
-			  "darkvision 30 ft."
-			],
-			"passive": 11,
-			"languages": [
-			  "quickly learns commands in any language"
-			],
-			"cr": "1/4",
-			"trait": [
-			  {
-				"name": "Keen Perceptions",
-				"entries": [
-				  "The thuman has advantage on Wisdom (Perception) checks that rely on smell, hearing, or sight."
-				]
-			  },
-			  {
-				"name": "Loyal Protector",
-				"entries": [
-				  "The thuman has advantage on attack rolls against a creature if the creature that the thuman has pledged service to is within 5 feet."
-				]
-			  }
-			],
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The thuman can make two bite attacks."
-				]
-			  },
-			  {
-				"name": "Bite",
-				"entries": [
-				  "{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage."
-				]
-			  }
-			],
-			"traitTags": [
-			  "Keen Senses"
-			],
-			"senseTags": [
-			  "D"
-			],
-			"actionTags": [
-			  "Multiattack"
-			],
-			"languageTags": [
-			  "X"
-			],
-			"damageTags": [
-			  "P"
-			],
-			"miscTags": [
-			  "MW"
-			],
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					"A thuman looks much like a large hound, although it has a face that is almost human. Its tough, leathery flesh is covered in short hair except for a longer tuft at the top of its head that resembles a crest.",
-					{
-					  "type": "entries",
-					  "name": "In Service.",
-					  "entries": [
-						"Thumans are intelligent and affable companions, and rarely the masters of their own affairs, preferring instead to serve others, which they do loyally. They don’t speak, but they understand language well and can be trained to follow a vast number of commands. Thumans are almost never encountered in the wild; they actively seek the company of humans. The PCs likely encounter a thuman at the side of its master, usually someone with some previous experience exploring the legacy of the Ancients, or another creature that itself stepped out of an Ancients’ cache."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"There is an unwritten code among thuman masters to treat their companions extremely well-more like a friend or ally than a pet. The loss of a thuman companion is like the loss of a close family member."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Travonis Ul",
-			"source": "AotA",
-			"page": 239,
-			"size": "H",
-			"type": "aberration",
-			"alignment": [
-			  "N",
-			  "E"
-			],
-			"ac": [
-			  {
-				"ac": 18,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 142,
-			  "formula": "15d12 + 45"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 20,
-			"dex": 15,
-			"con": 19,
-			"int": 15,
-			"wis": 10,
-			"cha": 16,
-			"senses": [
-			  "truesight 120 ft."
-			],
-			"passive": 18,
-			"resist": [
-			  "acid",
-			  "cold",
-			  "fire",
-			  "lightning",
-			  "thunder"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "poisoned"
-			],
-			"languages": [
-			  "understands most languages but can't speak"
-			],
-			"cr": "10",
-			"trait": [
-			  {
-				"name": "Magic Resistance",
-				"entries": [
-				  "The travonis ul has advantage on saving throws against spells and other magical effects."
-				]
-			  },
-			  {
-				"name": "Magic Weapons",
-				"entries": [
-				  "The travonis ul's weapon attacks are magical."
-				]
-			  },
-			  {
-				"name": "Regeneration",
-				"entries": [
-				  "The travonis ul regains 10 hit points at the start of its turn if it has at least 1 hit point."
-				]
-			  },
-			  {
-				"name": "Tendril Strider",
-				"entries": [
-				  "The travonis ul's movement is unaffected by difficult terrain."
-				]
-			  }
-			],
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The travonis ul makes three attacks: one with its bite and two with its tendrils. If the travonis ul is grappling a creature, it can use smother once."
-				]
-			  },
-			  {
-				"name": "Bite",
-				"entries": [
-				  "{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}9 ({@damage 1d8 + 5}) piercing damage plus 7 ({@damage 2d6}) psychic damage."
-				]
-			  },
-			  {
-				"name": "Tendril",
-				"entries": [
-				  "{@atk mw} {@hit 9} to hit, reach 20 ft., one target. {@h}12 ({@damage 2d6 + 5}) slashing damage plus 7 ({@damage 2d6}) psychic damage. The target is {@condition grappled} (escape {@dc 19}) if it is a Large or smaller creature and the travonis ul doesn't have two other creatures {@condition grappled}."
-				]
-			  },
-			  {
-				"name": "Smother",
-				"entries": [
-				  "The travonis ul bites and tendril-batters the {@condition grappled} creature, having advantage on attack rolls to do so. Each hit deals an additional 4 ({@damage 1d6}) psychic damage."
-				]
-			  }
-			],
-			"traitTags": [
-			  "Magic Resistance",
-			  "Magic Weapons",
-			  "Regeneration"
-			],
-			"senseTags": [
-			  "U"
-			],
-			"actionTags": [
-			  "Multiattack"
-			],
-			"languageTags": [
-			  "CS"
-			],
-			"damageTags": [
-			  "P",
-			  "S",
-			  "Y"
-			],
-			"miscTags": [
-			  "MW",
-			  "RCH"
-			],
-			"conditionInflict": [
-			  "grappled"
-			],
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					"A writhing mass of tendrils 15 feet across and 12 feet high, a travonis ul is a creature from elsewhere that hunts for organic material to consume. Three to five tendrils are particularly long, with bulbous yellow eyes at approximately their midpoint. One broad tendril has a mouth with several mandibles. In addition to the damage a bite or bludgeoning tendril bash deals, the touch of a travonis ul causes great pain and disrupts nervous systems.",
-					{
-					  "type": "entries",
-					  "name": "Ancients Outsider.",
-					  "entries": [
-						"A travonis ul is an intelligent creature, but it’s utterly alien to almost everything, even to entities related to the Ancients. It doesn’t seem to speak, read, or use tools of any kind, but it clearly understands and respects the numenera. Is it from another plane? Another time? Another world? When it comes to the travonis ul, such questions may not have meaning."
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Unearthly Hunger.",
-					  "entries": [
-						"A travonis ul looks upon all other creatures as food or enemies (or both). Travonis ul are some of the most dangerous predators to be found among the Ancients’ ruins, or in neighboring lands. The alien creatures eat constantly, so when one moves into an area, it quickly depletes the region of flora and fauna. Intelligent inhabitants usually organize resistance or just flee."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Varakith",
-			"source": "AotA",
-			"page": 0,
-			"size": "L",
-			"type": "monstrosity",
-			"alignment": [
-			  "L",
-			  "E"
-			],
-			"ac": [
-			  {
-				"ac": 15,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 114,
-			  "formula": "12d10 + 48"
-			},
-			"speed": {
-			  "walk": 30,
-			  "burrow": 30
-			},
-			"str": 18,
-			"dex": 14,
-			"con": 18,
-			"int": 11,
-			"wis": 10,
-			"cha": 8,
-			"senses": [
-			  "tremorsense 120 ft."
-			],
-			"passive": 10,
-			"languages": [
-			  "Varakith"
-			],
-			"cr": "5",
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The varakith makes two attacks with its spearing legs."
-				]
-			  },
-			  {
-				"name": "Spearing Legs",
-				"entries": [
-				  "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage. Medium or smaller targets who are hit must also succeed on a {@dc 15} Strength saving throw, or be {@condition grappled} (escape {@dc 15}). A {@condition grappled} creature is attached to the varakith's back with hooks and spikes. Until this grapple ends, the target is {@condition restrained} and takes 7 ({@damage 2d6}) piercing damage each round, while the varakith gains a +1 bonus to AC. Up to three targets can be so {@condition grappled} at one time. Corpses continue to provide a bonus to AC."
-				]
-			  }
-			],
-			"senseTags": [
-			  "T"
-			],
-			"actionTags": [
-			  "Multiattack"
-			],
-			"damageTags": [
-			  "P"
-			],
-			"miscTags": [
-			  "MW"
-			],
-			"conditionInflict": [
-			  "restrained"
-			],
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					"A varakith is a vaguely insectlike creature, 10 feet long, with multiple legs that end in tips like spears. It uses these lances to skewer enemies and drain them of blood, after which the creature adds them to its own body to serve as armor. Varakith prefer to dwell alone or in pairs in any temperate or warmer region. They make nests underground.",
-					{
-					  "type": "entries",
-					  "name": "Singers, Not Mindless Beasts.",
-					  "entries": [
-						"The strange noises the varakith make are actually songs and have meaning. Varakith \"speak\" (or rather, \"sing\") by rubbing two of their legs together, which produces a trilling sound. The song that one sage translated went as follows: We fight and crush Gnash and drink The foe at our heels will be our bread The foe at our heels feeds victories yet to come Stronger today, stronger tomorrow We fight We crush We gnash"
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Coontempuous",
-					  "entries": [
-						"Varakith have a dark and bloodthirsty spirit with little respect for others. However, a creature that proves itself in combat might be considered worth speaking to if communication can be established. Varakith see the world as one big gladiatorial arena in which they must constantly prove themselves. Even a respected combatant is still a foe to be overcome eventually-long-term alliance is not possible. However, varakith are not particularly devious or duplicitous about their mindset. They make their feelings known."
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Subterranean Foes.",
-					  "entries": [
-						"Varakith are excellent foes for PCs exploring subterranean areas, and having these monstrous things turn out to be fairly intelligent is a nice twist. Consider a scenario in which a young man hires the PCs to find his brother who disappeared while exploring a cave in the hills. Only after long searches do the characters discover that the brother’s corpse now adorns the back of a vicious varakith."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"Varakith only appear after one or more Ancients’ caches open. Once loosed in the world, they likely war against subterranean communities they find in the sunless deeps."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Xi-Drake",
-			"source": "AotA",
-			"page": 241,
-			"size": "H",
-			"type": "monstrosity",
-			"alignment": [
-			  "N",
-			  "G"
-			],
-			"ac": [
-			  {
-				"ac": 14,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 85,
-			  "formula": "9d12 + 27"
-			},
-			"speed": {
-			  "walk": 30,
-			  "fly": 120
-			},
-			"str": 20,
-			"dex": 18,
-			"con": 17,
-			"int": 12,
-			"wis": 18,
-			"cha": 14,
-			"senses": [
-			  "darkvision 120 ft."
-			],
-			"passive": 14,
-			"languages": [
-			  "telepathy 120 ft. (only to receive thoughts, not to send)"
-			],
-			"cr": "5",
-			"trait": [
-			  {
-				"name": "Flyby",
-				"entries": [
-				  "The xi-drake doesn't provoke an opportunity attack when it ends its movement out of an enemy's reach."
-				]
-			  },
-			  {
-				"name": "Magic Resistance",
-				"entries": [
-				  "The xi-drake has advantage on saving throws against spells and other magical effects."
-				]
-			  }
-			],
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The xi-drake makes one bite and one tail slam attack."
-				]
-			  },
-			  {
-				"name": "Bite",
-				"entries": [
-				  "{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}21 ({@damage 3d10 + 5}) piercing damage, and the target is {@condition grappled}"
-				]
-			  },
-			  {
-				"name": "(escape {@dc 16})",
-				"entries": [
-				  "Until this grapple ends, the target is {@condition restrained}, and the xi-drake can't bite another target."
-				]
-			  },
-			  {
-				"name": "Tail Slam",
-				"entries": [
-				  "{@atk mw} {@hit 8} to hit, reach 10 ft., one target. {@h}14 ({@damage 2d8 + 5}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 16} Strength saving throw or be knocked {@condition prone}."
-				]
-			  },
-			  {
-				"name": "Read Thoughts",
-				"entries": [
-				  "The xi-drake telepathically reads the surface thoughts of one creature within 120 feet that it can see as a bonus action. While the target is in range, the xi-drake can continue reading its thoughts, even if taking normal actions.",
-				  "While reading the target's mind, the xi-drake has advantage on Wisdom (Insight) and Charisma (Persuasion) checks against the target. A creature aware of the mind-reading who doesn't want their mind to be read must succeed on a {@dc 17} Wisdom saving throw, which confers a day's immunity if successful."
-				]
-			  }
-			],
-			"reaction": [
-			  {
-				"name": "Anticipate Attack (5-6)",
-				"entries": [
-				  "The xi-drake anticipates one melee attack that would hit it and negates it. To do so, the xi-drake must be reading the target's thoughts."
-				]
-			  }
-			],
-			"traitTags": [
-			  "Flyby",
-			  "Magic Resistance"
-			],
-			"senseTags": [
-			  "SD"
-			],
-			"actionTags": [
-			  "Multiattack"
-			],
-			"languageTags": [
-			  "TP"
-			],
-			"damageTags": [
-			  "B",
-			  "P"
-			],
-			"miscTags": [
-			  "MW",
-			  "RCH"
-			],
-			"conditionInflict": [
-			  "grappled",
-			  "prone",
-			  "restrained"
-			],
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					"Xi-drakes sometimes darken the skies over Ancients’ caches. Their massive size, white skin, reptile-like form with broad wings, and long tail means they are sometimes confused with different creatures entirely.",
-					{
-					  "type": "entries",
-					  "name": "Mind Readers.",
-					  "entries": [
-						"Xi-drakes have keen senses, but more impressively, they can read the mind of any intelligent living creature within 120 feet and thus are almost impossible to deceive."
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Sociable, Amenable to Pacts.",
-					  "entries": [
-						"Though telepathic, they cannot speak (telepathically or otherwise). However, their ability to read minds allows a sort of communication. They are not so much tamed or trained as they are befriended. Sometimes they enter into pacts with individuals (or groups), and serve as mounts. Once a xi-drake is bound to a rider/ companion, the two work in concert until death (usually the death of the rider, since xidrakes live for hundreds of years)."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"Xi-drakes, decanted from stasis pods by explorers, seem willing to interact with whatever creatures they encounter."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Yellow Swarm",
-			"source": "AotA",
-			"page": 242,
-			"size": "M",
-			"type": {
-			  "type": "beast",
-			  "swarmSize": "T"
-			},
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 14,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 65,
-			  "formula": "10d8 + 20"
-			},
-			"speed": {
-			  "walk": 0,
-			  "fly": {
-				"number": 20,
-				"condition": "(hover)"
-			  },
-			  "canHover": true
-			},
-			"str": 17,
-			"dex": 15,
-			"con": 15,
-			"int": 2,
-			"wis": 11,
-			"cha": 13,
-			"senses": [
-			  "blindsight 60 ft."
-			],
-			"passive": 10,
-			"resist": [
-			  "bludgeoning",
-			  "piercing",
-			  "slashing"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "frightened",
-			  "grappled",
-			  "paralyzed",
-			  "petrified",
-			  "prone",
-			  "restrained",
-			  "stunned"
-			],
-			"trait": [
-			  {
-				"name": "Swarm",
-				"entries": [
-				  "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
-				]
-			  }
-			],
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The yellow swarm makes three bites attacks."
-				]
-			  },
-			  {
-				"name": "Bites",
-				"entries": [
-				  "{@atk mw} {@hit 5} to hit, reach 0 ft., one target in the swarm's space. {@h}17 ({@damage 4d6 + 3}) piercing damage, or 10 ({@damage 2d6 + 3}) piercing damage if the swarm has half of its hit points or fewer."
-				]
-			  },
-			  {
-				"name": "Reality Phase {@recharge 4}",
-				"entries": [
-				  "The yellow swarm fades into a different reality not normally accessible by other creatures for one round, rendering attacks against it moot. Before or after reality phase, the yellow swarm can make one bites attack."
-				]
-			  }
-			],
-			"senseTags": [
-			  "B"
-			],
-			"actionTags": [
-			  "Multiattack"
-			],
-			"damageTags": [
-			  "P"
-			],
-			"miscTags": [
-			  "MW"
-			],
-			"cr": "4",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					"Yellow swarms are groups of insect-like creatures. They must stay in close proximity to one another, or they lose their ability to remain on this plane of existence. They look like a small cloud of yellow locusts until you get close enough to see that they are transparent and oddly configured, with asymmetrical bodies that have seven legs and five wings.",
-					{
-					  "type": "entries",
-					  "name": "Hunger for Brain Fluids.",
-					  "entries": [
-						"Yellow swarms feed on various chemicals in the brains and spines of living creatures. Defending against this hunger is tough because a yellow swarm is always fading in and out of reality. Yellow swarms often linger near interdimensional gates or other access points, so the presence of a swarm is a good indicator that a gate is nearby."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Yovok",
-			"source": "AotA",
-			"page": 243,
-			"size": "S",
-			"type": {
-			  "type": "humanoid",
-			  "tags": [
-				"yovok"
-			  ]
-			},
-			"alignment": [
-			  "C",
-			  "N"
-			],
-			"ac": [
-			  {
-				"ac": 14,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 14,
-			  "formula": "4d6 + 4"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 10,
-			"dex": 16,
-			"con": 13,
-			"int": 9,
-			"wis": 10,
-			"cha": 10,
-			"skill": {
-			  "athletics": "+4"
-			},
-			"senses": [
-			  "darkvision 60 ft."
-			],
-			"passive": 10,
-			"languages": [
-			  "Yovok",
-			  "some understand Common"
-			],
-			"cr": "1/4",
-			"action": [
-			  {
-				"name": "Spear",
-				"entries": [
-				  "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage."
-				]
-			  },
-			  {
-				"name": "Barb Spit {@recharge 5}",
-				"entries": [
-				  "{@atk rw} {@hit 5} to hit, range 40 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage, and target must succeed on a {@dc 13} Constitution saving throw or become {@condition paralyzed} for the next four rounds."
-				]
-			  }
-			],
-			"senseTags": [
-			  "D"
-			],
-			"languageTags": [
-			  "C"
-			],
-			"damageTags": [
-			  "P"
-			],
-			"miscTags": [
-			  "MW",
-			  "RW"
-			],
-			"conditionInflict": [
-			  "paralyzed"
-			],
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					"The horrid yovoki are short, squat, corrupt humanoids with jaundiced skin draped loosely over their flabby, hairless bodies. They hunt and kill for pleasure, although they happily eat whatever they kill as well. In fact, they eat constantly and seem able to digest almost anything. Yovoki wander in small groups of three to six in the mountains and hills.",
-					{
-					  "type": "entries",
-					  "name": "Savage Humanoid Effigies.",
-					  "entries": [
-						"Yovoki are too disordered to have a strict group hierarchy. Instead, they all just yell and snort and squeal until one of them gets their way. There are two yovoki genders, but sometimes even they cannot tell the difference between their males and females. They kill for pleasure, food, and as displays of strength."
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Gutter Schemers.",
-					  "entries": [
-						"Fast-talking characters might be able to reason with yovoki, but doing so is difficult due to their bloodlust. It might be easier for the PCs to intimidate or frighten them into compliance. Despite their corrupt and savage nature, some are smart enough to use numenera devices or hatch simple plots to get what they want-poisoning wells, kidnapping important people, and so on."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"Like killisti, yovoki are apparently humans mutated by numenera devices, possibly purposefully, though to what end and by what is unknown."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"Each yovok has a spear, club, or other melee weapon. A group of yovoki has at least one cypher among them."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Zhev",
-			"source": "AotA",
-			"page": 244,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-			  "L",
-			  "G"
-			],
-			"ac": [
-			  {
-				"ac": 20,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 60,
-			  "formula": "8d8 + 24"
-			},
-			"speed": {
-			  "walk": 0,
-			  "fly": {
-				"number": 60,
-				"condition": "(hover)"
-			  },
-			  "canHover": true
-			},
-			"str": 17,
-			"dex": 12,
-			"con": 16,
-			"int": 10,
-			"wis": 10,
-			"cha": 10,
-			"skill": {
-			  "perception": "+4"
-			},
-			"senses": [
-			  "blindsight 120 ft. (blind beyond this radius)"
-			],
-			"passive": 14,
-			"resist": [
-			  {
-				"resist": [
-				  "bludgeoning",
-				  "piercing",
-				  "slashing"
-				],
-				"note": "from nonmagical attacks not made with adamantine weapons"
-			  }
-			],
-			"immune": [
-			  "force",
-			  "necrotic",
-			  "poison"
-			],
-			"conditionImmune": [
-			  "blinded",
-			  "charmed",
-			  "deafened",
-			  "frightened",
-			  "paralyzed",
-			  "petrified",
-			  "poisoned",
-			  "stunned"
-			],
-			"languages": [
-			  "Zhev",
-			  "some understand Common"
-			],
-			"cr": "4",
-			"trait": [
-			  {
-				"name": "Magic Resistance",
-				"entries": [
-				  "The Zhev has advantage on saving throws against spells and other magical effects."
-				]
-			  },
-			  {
-				"name": "Magic Weapons",
-				"entries": [
-				  "The Zhev's weapon attacks are treated as if magical."
-				]
-			  }
-			],
-			"action": [
-			  {
-				"name": "Multiattack",
-				"entries": [
-				  "The Zhev makes three tentacular arm attacks."
-				]
-			  },
-			  {
-				"name": "Tentacular Arm",
-				"entries": [
-				  "{@atk mw} {@hit 6} to hit, reach 10 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage."
-				]
-			  },
-			  {
-				"name": "Net",
-				"entries": [
-				  "{@atk rw} {@hit 3} to hit, range 5/15 ft., one Large or smaller creature. {@h}The target is {@condition restrained}. A creature can use its action to make a {@dc 15} Strength check to free itself or another creature in a net, ending the effect on a success.",
-				  "Dealing 5 slashing damage to the net (AC 15) frees the target without harming it and destroys the net."
-				]
-			  },
-			  {
-				"name": "Incapacitating Gas {@recharge 5}",
-				"entries": [
-				  "The Zhev fires a canister to a point within 120 feet that it can see, which then detonates.",
-				  "Each creature in a 20-foot-radius sphere centered on that point must succeed on a {@dc 15} Constitution saving throw or be {@condition incapacitated} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
-				]
-			  }
-			],
-			"traitTags": [
-			  "Magic Resistance",
-			  "Magic Weapons"
-			],
-			"senseTags": [
-			  "B"
-			],
-			"actionTags": [
-			  "Multiattack"
-			],
-			"languageTags": [
-			  "C"
-			],
-			"damageTags": [
-			  "B"
-			],
-			"miscTags": [
-			  "AOE",
-			  "MW",
-			  "RCH",
-			  "RW",
-			  "THW"
-			],
-			"conditionInflict": [
-			  "incapacitated",
-			  "restrained"
-			],
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "inset",
-					  "entries": [
-						"Zhev seem inclined to prevent infractions of the law and act to preserve order, keep the peace, and protect the lives of innocents."
-					  ]
-					},
-					"Zhev are cylinders 6 feet high and 3 feet in diameter, and typically hover 3 feet off the ground. Their three triangular eyes appear to be organic. The eyes usually stay together in a larger triangle formation, moving inside the cylinder, peering through a slit near the top that goes all the way around. The eyes can also separate, each looking in a different direction, but they do this rarely.",
-					{
-					  "type": "entries",
-					  "name": "Biomechanical and Resolute.",
-					  "entries": [
-						"Although the Zhev are essentially constructs, they have organic interior components as well as mechanical parts. When activated, they either return to whatever Ancients’ command they last received (which likely makes little sense in their new context) or look for new instructions."
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Enforcers of Law.",
-					  "entries": [
-						"If a group of Zhev find themselves at loose ends, they may offer their services to a city or other location. If a pact is agreed to, affected Zhev obey the orders given to them by their new hosts. Other people cannot reason or negotiate with the Zhev. They are relentless and merciless, though they first attempt to capture criminals rather than use violent or lethal force. Usually, the Zhev seem inclined to prevent infractions of the law and act to preserve order, keep the peace, and protect the lives of innocents. When forced to choose between options, they always make the choice that saves the most people from the greatest harm. Protecting innocents takes priority over enforcing laws, assuming Zhev in the area even know what local laws might apply."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"PCs who run afoul of the Zhev have likely done something very wrong."
-					  ]
-					},
-					{
-					  "type": "inset",
-					  "entries": [
-						"The Zhev usually begin a fight by firing stun gas canisters or nets. If the gas and nets fail, Zhev physically attack."
-					  ]
-					},
-					{
-					  "type": "entries",
-					  "name": "Salvage.",
-					  "entries": [
-						"The body of a defeated Zhev can be scavenged for a cypher, and sometimes (1 in 1d10) a relic."
-					  ]
-					},
-					{
-						"type": "insetReadaloud",
-						"entries": [
-						  {
-							"type":"quote",
-							"entries":[
-								"But how well does their metal hide stand up to an axe? Now that’s a question that wants an answer."
-							],
-							"by":"Faim Trubeard, dwarf veteran and prospector"
-						  }
-						]
-					  },
-					  {
-						  "type": "inset",
-						  "entries": [
-							{
-							  "type":"quote",
-							  "entries":[
-								"Why? They seem peaceable enough. Civic-minded, one might say."
-							  ],
-							  "by":"Elmande, elf mage and scholar"
-							}
-						  ]
-						},
-						{
-							"type": "insetReadaloud",
-							"entries": [
-							  {
-								"type":"quote",
-								"entries":[
-									"They’re not natural, is why. Sure, the one we met saved us from that machine demon, thank the Forge. I appreciate that. But you're the one who pointed out what the quotien lore said about these Zhev—theyll always act to ensure a just outcome for the largest number of innocent beings, not matter what. Which means that if they have to kill five folks to save six, then those five had better be right with their gods. And that just isn’t right. Plus, why is it Zhev with a capitol 'Z'?"
-								],
-								"by":"Faim Trubeard, dwarf veteran and prospector"
-							  }
-							]
-						  }
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Basic Automaton, Type One",
-			"source": "AotA",
-			"page": 246,
-			"size": "T",
-			"type": "construct",
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 11,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 10,
-			  "formula": "4d4"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 3,
-			"dex": 10,
-			"con": 10,
-			"int": 8,
-			"wis": 8,
-			"cha": 5,
-			"passive": 9,
-			"immune": [
-			  "poison"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "deafened",
-			  "exhaustion",
-			  "frightened",
-			  "paralyzed",
-			  "petrified",
-			  "poisoned"
-			],
-			"trait": [
-				{
-					"name": "Skill Proficiency",
-					"entries": [
-						"The Automaton may use any one skill with profficiency +1"
-					]
-				}
-			],
-			"action": [
-			  {
-				"name": "Melee Attack",
-				"entries": [
-				  "Melee Weapon Attack:{@hit -2} to hit, reach 5 ft., one target. {@h}1 slashing damage."
-				]
-			  },
-			  {
-				"name": "Ranged Attack",
-				"entries": [
-				  "{@atk rw} {@hit 2} to hit, range",
-				  "30/60 ft., one target. {@h}1 piercing damage."
-				]
-			  }
-			],
-			"damageTags": [
-			  "P",
-			  "S"
-			],
-			"miscTags": [
-			  "RW"
-			],
-			"cr": "1/8",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "inset",
-					  "entries": [
-						"The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
-					  ]
-					},
-					"The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
-					{
-					  "type": "inset",
-					  "entries": [
-						"The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Basic Automaton, Type Two",
-			"source": "AotA",
-			"page": 246,
-			"size": "S",
-			"type": "construct",
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 11,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 35,
-			  "formula": "8d6 + 8"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 7,
-			"dex": 13,
-			"con": 13,
-			"int": 10,
-			"wis": 10,
-			"cha": 7,
-
-			"passive": 10,
-			"immune": [
-			  "poison"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "deafened",
-			  "exhaustion",
-			  "frightened",
-			  "paralyzed",
-			  "petrified",
-			  "poisoned"
-			],
-			"trait": [
-				{
-					"name": "Skill Proficiency",
-					"entries": [
-						"The Automaton may use any one skill with profficiency +2"
-					]
-				}
-			],
-			"action": [
-			  {
-				"name": "Melee Attack",
-				"entries": [
-				  "{@atk mw} {@hit 0} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) slashing damage."
-				]
-			  },
-			  {
-				"name": "Ranged Attack",
-				"entries": [
-				  "{@atk rw} {@hit 3} to hit, range",
-				  "30/60 ft., one target. {@h}3 ({@damage 1d4 + 1}) piercing damage."
-				]
-			  }
-			],
-			"damageTags": [
-			  "P",
-			  "S"
-			],
-			"miscTags": [
-			  "MW",
-			  "RW"
-			],
-			"cr": "1/4",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "inset",
-					  "entries": [
-						"The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
-					  ]
-					},
-					"The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
-					{
-					  "type": "inset",
-					  "entries": [
-						"The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Basic Automaton, Type Three",
-			"source": "AotA",
-			"page": 247,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 13,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 65,
-			  "formula": "10d8 + 20"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 15,
-			"dex": 13,
-			"con": 15,
-			"int": 10,
-			"wis": 12,
-			"cha": 7,
-			"save": {
-			  "str": "+4"
-			},
-
-			"passive": 11,
-			"immune": [
-			  "poison"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "deafened",
-			  "exhaustion",
-			  "frightened",
-			  "paralyzed",
-			  "petrified",
-			  "poisoned"
-			],
-			"trait": [
-				{
-					"name": "Skill Proficiency",
-					"entries": [
-						"The Automaton may use any one skill with profficiency +2"
-					]
-				}
-			],
-			"action": [
-			  {
-				"name": "Melee Attack",
-				"entries": [
-				  "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 2}) slashing damage."
-				]
-			  },
-			  {
-				"name": "Ranged Attack",
-				"entries": [
-				  "{@atk rw} {@hit 3} to hit, range",
-				  "30/60 ft., one target. {@h}8 ({@damage 2d6 + 1}) piercing damage."
-				]
-			  }
-			],
-			"damageTags": [
-			  "P",
-			  "S"
-			],
-			"miscTags": [
-			  "MW",
-			  "RW"
-			],
-			"cr": "1/4",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "inset",
-					  "entries": [
-						"The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
-					  ]
-					},
-					"The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
-					{
-					  "type": "inset",
-					  "entries": [
-						"The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Basic Automaton, Type Four",
-			"source": "AotA",
-			"page": 247,
-			"size": "M",
-			"type": "construct",
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 15,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 90,
-			  "formula": "12d8 + 36"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 17,
-			"dex": 13,
-			"con": 17,
-			"int": 10,
-			"wis": 12,
-			"cha": 7,
-			"save": {
-			  "str": "+5"
-			},
-			"passive": 11,
-			"immune": [
-			  "poison"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "deafened",
-			  "exhaustion",
-			  "frightened",
-			  "paralyzed",
-			  "petrified",
-			  "poisoned"
-			],
-			"trait": [
-				{
-					"name": "Skill Proficiency",
-					"entries": [
-						"The Automaton may use any one skill with profficiency +2"
-					]
-				}
-			],
-			"action": [
-			  {
-				"name": "Melee Attack",
-				"entries": [
-				  "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}17 ({@damage 4d6 + 3}) slashing damage."
-				]
-			  },
-			  {
-				"name": "Ranged Attack",
-				"entries": [
-				  "{@atk rw} {@hit 3} to hit, range",
-				  "30/60 ft., one target. {@h}15 ({@damage 4d6 + 1}) piercing damage."
-				]
-			  }
-			],
-			"damageTags": [
-			  "P",
-			  "S"
-			],
-			"miscTags": [
-			  "MW",
-			  "RW"
-			],
-			"cr": "4",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "inset",
-					  "entries": [
-						"The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
-					  ]
-					},
-					"The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
-					{
-					  "type": "inset",
-					  "entries": [
-						"The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  },
-		  {
-			"name": "Basic Automaton, Type Five",
-			"source": "AotA",
-			"page": 248,
-			"size": "L",
-			"type": "construct",
-			"alignment": [
-			  "U"
-			],
-			"ac": [
-			  {
-				"ac": 15,
-				"from": [
-				  "natural armor"
-				]
-			  }
-			],
-			"hp": {
-			  "average": 133,
-			  "formula": "14d10 + 56"
-			},
-			"speed": {
-			  "walk": 30
-			},
-			"str": 19,
-			"dex": 13,
-			"con": 19,
-			"int": 10,
-			"wis": 12,
-			"cha": 7,
-			"save": {
-			  "str": "+7"
-			},
-			"passive": 11,
-			"immune": [
-			  "poison"
-			],
-			"conditionImmune": [
-			  "charmed",
-			  "deafened",
-			  "exhaustion",
-			  "frightened",
-			  "paralyzed",
-			  "petrified",
-			  "poisoned"
-			],
-			"trait": [
-				{
-					"name": "Skill Proficiency",
-					"entries": [
-						"The Automaton may use any one skill with profficiency +3"
-					]
-				}
-			],
-			"action": [
-			  {
-				"name": "Melee Attack",
-				"entries": [
-				  "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}32 ({@damage 8d6 + 4}) slashing damage."
-				]
-			  },
-			  {
-				"name": "Ranged Attack",
-				"entries": [
-				  "{@atk rw} {@hit 4} to hit, range",
-				  "30/60 ft., one target. {@h}29 ({@damage 8d6 + 1}) piercing damage."
-				]
-			  }
-			],
-			"damageTags": [
-			  "P",
-			  "S"
-			],
-			"miscTags": [
-			  "MW",
-			  "RW"
-			],
-			"cr": "6",
-			"fluff": {
-			  "entries": [
-				{
-				  "type": "entries",
-				  "entries": [
-					{
-					  "type": "inset",
-					  "entries": [
-						"The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
-					  ]
-					},
-					"The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
-					{
-					  "type": "inset",
-					  "entries": [
-						"The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
-					  ]
-					}
-				  ]
-				}
-			  ]
-			}
-		  }
-	]
+  "_meta": {
+    "sources": [
+      {
+        "json": "AotA",
+        "abbreviation": "AotA",
+        "full": "Arcana of the Ancients",
+        "color": "6441A4",
+        "version": "",
+        "url": "https://www.montecookgames.com/store/product/arcana-of-the-ancients/",
+        "authors": [
+          "Sean K. Reynolds",
+          "Bruce R. Cordell",
+          "Monte Cook"
+        ],
+        "convertedBy": [
+          "attanaz"
+        ]
+      }
+    ],
+    "dateAdded": 1591117986,
+    "dateLastModified": 1591117986
+  },
+  "monster": [
+    {
+      "name": "Accelerator",
+      "source": "AotA",
+      "page": 142,
+      "size": "H",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 19,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 195,
+        "formula": "17d12 + 85"
+      },
+      "speed": {
+        "walk": 60,
+        "fly": {
+          "number": 10,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 22,
+      "dex": 12,
+      "con": 20,
+      "int": 16,
+      "wis": 16,
+      "cha": 14,
+      "save": {
+        "con": "+9",
+        "int": "+7",
+        "wis": "+7",
+        "cha": "+6"
+      },
+      "skill": {
+        "perception": "+7"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 17,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "several ancient languages",
+        "can learn a new language in minutes"
+      ],
+      "cr": "10",
+      "trait": [
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The accelerator's attacks are treated as if magical."
+          ]
+        },
+        {
+          "name": "Paranoid and Fearful",
+          "entries": [
+            "It is very difficult to gain an accelerator's trust. Creatures have disadvantage on attempts to convince it that they aren't a threat. If successful, they only make it indifferent and wary for a few minutes, or perhaps an hour at most."
+          ]
+        },
+        {
+          "name": "Modification (Recharges after a Short or Long Rest)",
+          "entries": [
+            "About one in four accelerators have found a way to install a device within its shell that gives it an additional ability as a bonus action.",
+            "Typically these devices are one of the following: a force field that adds +2 AC for one minute, a rocket pack that lets it move up to 500 feet, or a mental scrambler that gives all living creatures within 60 feet disadvantage on all rolls their next round."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The accelerator makes three claw attacks and uses its control velocity ability."
+          ]
+        },
+        {
+          "name": "Claw",
+          "entries": [
+            "{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}19 ({@damage 3d8 + 6}) slashing damage."
+          ]
+        },
+        {
+          "name": "Control Velocity",
+          "entries": [
+            "The accelerator can change the speed and direction of up to three objects and creatures within 10 feet, such as halting a moving creature or causing a still object to suddenly move rapidly in any direction. Typically it uses this to hurl a light object (up to 50 pounds), hurl a heavy object (up to 100 pounds), hurl a foe (up to 300 pounds), or stop a moving creature or object (up to 300 pounds)."
+          ]
+        },
+        {
+          "name": "Hurl Light Object",
+          "entries": [
+            "{@atk rw} {@hit 7} to hit, range",
+            "150/600 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Hurl Heavy Object",
+          "entries": [
+            "{@atk rw} {@hit 7} to hit, range",
+            "30/60 ft., one target. {@h}12 ({@damage 2d8 + 3}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Hurl Foe",
+          "entries": [
+            "The target must succeed on a {@dc 15} Strength or Dexterity saving throw (target's choice) or be thrown up to 60 feet away, taking 12 ({@damage 2d8 + 3}) bludgeoning damage from impacting the ground or a solid obstacle."
+          ]
+        },
+        {
+          "name": "Stop Movement",
+          "entries": [
+            "The target must succeed on a {@dc 15} Strength or Dexterity saving throw (target's choice) or be {@condition grappled} and {@condition restrained} in its current space for one round."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH",
+        "RW"
+      ],
+      "conditionInflict": [
+        "grappled",
+        "restrained"
+      ],
+      "tokenUrl": "",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "An accelerator is an artificial intelligence encased in a metal shell with numerous limbs, sensory devices, and other accoutrements that allow it to interact with and understand the world around itself. An accelerator fears “death” (perhaps “dissolution” is a better term) and concocts elaborate plans to develop better protections for itself. Ironically, sometimes this puts it in danger as it tries to take control of a defensible fortress or obtain a device that will grant it a powerful defense. A fully upright accelerator stands 15 feet high. Paranoia. Accelerators aren’t evil, but their interest in putting their own existence ahead of others means they might act in ways that people consider villainous. If seriously threatened, an accelerator always chooses flight over fight.",
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "It is fascinating that such a large and powerful creature would be so fearful of death that its entire existence is a desperate obsession with survival. It makes me wonder what horrors it survived ages ago that led it to where it is now—perhaps its kind are the last survivors of a great cataclysm, war, or divine retribution."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "I’m just glad they’re not interested in conquest. If they were aggressive like chromatic dragons or fire giants . . . with their knowledge and skills, they could attack a town and leave nothing but corpses."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Paranoia",
+                "entries": [
+                  "Accelerators aren’t evil, but their interest in putting their own existence ahead of others means they might act in ways that people consider villainous. If seriously threatened, an accelerator always chooses flight over fight."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "A destroyed ccelerator can be salvaged for up to 1d6 + 1 cyphers and one oddity"
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_144_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_144_Image_0002.png"
+    },
+    {
+      "name": "Aliopter",
+      "source": "AotA",
+      "page": 144,
+      "size": "L",
+      "type": "aberration",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 142,
+        "formula": "15d10 + 60"
+      },
+      "speed": {
+        "walk": 30,
+        "fly": {
+          "number": 100,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 16,
+      "dex": 14,
+      "con": 18,
+      "int": 2,
+      "wis": 12,
+      "cha": 5,
+      "save": {
+        "str": "+6",
+        "con": "+7"
+      },
+      "skill": {
+        "perception": "+4",
+        "stealth": "+5"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 14,
+      "resist": [
+        "bludgeoning"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "prone"
+      ],
+      "languages": [
+        ""
+      ],
+      "cr": "8",
+      "trait": [
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The aliopter's attacks are treated as if magical."
+          ]
+        },
+        {
+          "name": "Reactive Tongues",
+          "entries": [
+            "An aliopter has four reactions that can be used only for opportunity attacks."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The aliopter makes four barbed tongue attacks."
+          ]
+        },
+        {
+          "name": "Barbed Tongue",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d10 + 3}) slashing damage. If the target is a Medium or smaller creature, it must succeed on a {@dc 15} Strength or Dexterity saving throw or be {@condition grappled} and {@condition restrained} (escape {@dc 15}). If the target is a living creature, it also must succeed on a {@dc 16} Constitution saving throw or be infected with a disease—a cluster of aliopter larvae.",
+            "The aliopter larvae live and grow beneath the target's flesh for about a week, after which they move to the creature's tongue and cause it to swell. Eventually the victim's throat becomes blocked by the swollen tongue and they begin to choke; every 10 minutes they must succeed on a {@dc 16} Constitution saving throw or start suffocating. After six hours of this, the tongue ruptures, and tiny aliopters squirm out.",
+            "If the target is dead, the young alioptors feed on the corpse before joining together into a single mass and begin searching for new prey.",
+            "The aliopter's reproductive process holds true for most humanoid creatures. It might take a different form in another creature, such as growing in the target's stomach or lungs before bursting out and eating the dead host.",
+            "If the disease is cured before the larvae's emergence, the unborn aliopters are disintegrated."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "grappled",
+        "restrained"
+      ],
+      "tokenUrl": "",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "An aliopter looks like a horrific cloud ofwrithing, undulating tongues. It is a colony of many organisms fused together into one composite creature weighing several hundred pounds. It sweeps out of the cover of shadows to attack prey, flying by some unknown means of negating gravity in a precisely controlled manner. They seem to originate from ancient ruins, particularly those with a connection to another world orbiting a far-off star.",
+              {
+                "type": "entries",
+                "name": "Hunger and Reproduction.",
+                "entries": [
+                  "An aliopter’sonly motive is to feed and reproduce. It is a near-mindless predator that cannot be reasoned with. Once it has successfully injected its larvae into a victim, it focuses on feeding for the next few months and no longer attempts to implant anything."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_146_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_146_Image_0002.png"
+    },
+    {
+      "name": "Anhedon",
+      "source": "AotA",
+      "page": 145,
+      "size": "M",
+      "type": "monstrosity",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 90,
+        "formula": "12d8 + 36"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 16,
+      "dex": 10,
+      "con": 16,
+      "int": 14,
+      "wis": 13,
+      "cha": 11,
+      "save": {
+        "str": "+5",
+        "con": "+5"
+      },
+      "skill": {
+        "arcana": "+4"
+      },
+      "passive": 13,
+      "resist": [
+        "bludgeoning"
+      ],
+      "languages": [
+        "Anhedon and usually two or three others"
+      ],
+      "cr": "4",
+      "trait": [
+        {
+          "name": "Red Eyes",
+          "entries": [
+            "An anhedon cannot see in darkness, but its eyes emit red light that allows it to see up to 60 feet as if it were bright light."
+          ]
+        },
+        {
+          "name": "Safe Falling",
+          "entries": [
+            "Because it subconsciously manipulates gravity to land safely, an anhedon never takes falling damage."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Crushing Gravity",
+          "entries": [
+            "An anhedon can increase gravity on a",
+            "Medium or smaller target within 60 feet. The target must make a {@dc 15} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone}, {@condition restrained}, and take 13 ({@damage 3d6 + 3}) bludgeoning damage. On a successful save, the target takes only half damage and isn't knocked {@condition prone} or {@condition restrained}. A {@condition restrained} target can attempt a save every round to escape this force, otherwise it takes damage again and continues to be held {@condition prone} and {@condition restrained}. The anhedon can only restrain one creature at a time with this ability."
+          ]
+        },
+        {
+          "name": "Cancel or Reverse Gravity",
+          "entries": [
+            "An anhedon can cancel gravity for a target within 60 feet, making it float around like a feather on the wind until it can escape, or reverse gravity completely on the target for one round, causing it to fall up to 100 feet up and then down again, taking {@damage 1d6} bludgeoning damage per 10 feet fallen. A creature can resist the gravity effect with a successful {@dc 13} Strength or Dexterity saving throw (target's choice) to grab onto a fixed object within reach to prevent itself from falling up."
+          ]
+        },
+        {
+          "name": "Deadly Leap",
+          "entries": [
+            "An anhedon can decrease and increase gravity on itself as it jumps so that it smashes to the ground up to 100 feet away from its starting point. All creatures within 10 feet of where it lands it must succeed on a {@dc 13} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 13 ({@damage 3d6 + 3}) bludgeoning damage. On a successful save, the creature takes only half damage and isn't knocked {@condition prone}."
+          ]
+        }
+      ],
+      "damageTags": [
+        "B"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "prone",
+        "restrained"
+      ],
+      "tokenUrl": "",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Dour and severe, anhedons are humanoid-shaped creatures protected with a carapace of dark stone breached only by twin beams of red light for eyes. It is possible that this carapace is actually some kind of stone armor powered by geological forces.",
+              {
+                "type": "entries",
+                "name": "Obsessed Searcher",
+                "entries": [
+                  "Anhedons are searching for something they call the Meeting of All Things—a thing they will name but never describe. They negotiate with those who seem like they could help with this goal, but woe to those who lie about knowing where to find what the anhedons seek. They are otherwise hateful creatures that would rather kill other beings than negotiate with."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Mysterious Origin.",
+                "entries": [
+                  "Origin. Anhedons seem to simply (and literally) fall out of the sky and start working on finding information about the Meeting of All Things. They don’t seem to have families or young, or at least not on this world, and they don’t have lairs, only remaining in one place as long as necessary to exhaust all avenues of inquiry relevant to that location."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "Anhedon carapace or armor can be be salvaged for a couple of cyphers and two to three oddities"
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_147_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_147_Image_0002.png"
+    },
+    {
+      "name": "Arric Frog",
+      "source": "AotA",
+      "page": 146,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 120,
+        "formula": "16d10 + 12"
+      },
+      "speed": {
+        "walk": 50,
+        "swim": 30
+      },
+      "str": 15,
+      "dex": 13,
+      "con": 15,
+      "int": 2,
+      "wis": 10,
+      "cha": 3,
+      "save": {
+        "str": "+5",
+        "con": "+6"
+      },
+      "skill": {
+        "athletics": "+5",
+        "perception": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "cr": "5",
+      "trait": [
+        {
+          "name": "Amphibious",
+          "entries": [
+            "The arric frog can breathe air and water."
+          ]
+        },
+        {
+          "name": "Standing Leap",
+          "entries": [
+            "The arric frog's long jump is up to 20 feet and its high jump is up to 10 feet, with or without a running start."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}29 ({@damage 6d8 + 2}) piercing damage. If the target is a Medium or smaller creature, it must succeed on a {@dc 13} Strength saving throw or be knocked {@condition prone}."
+          ]
+        },
+        {
+          "name": "Swallow",
+          "entries": [
+            "The frog uses its sticky tongue against a Small or smaller creature or metallic object (such as a cypher) within 5 feet. The target must succeed on a {@dc 13} Strength or Dexterity saving throw; failure means the frog yanks the creature or object away and swallows it. The swallowed target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the frog, and it takes 10 ({@damage 3d6}) acid damage at the start of each of the frog's turns. The frog can have up to two targets swallowed at a time.",
+            "If the frog dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse using 5 feet of movement, exiting {@condition prone}."
+          ]
+        },
+        {
+          "name": "Spit Cyst {@recharge}",
+          "entries": [
+            "The frog can spit a biomechanical cyst at a location within 60 feet, which explodes in a 5-foot-radius sphere, dealing 14 ({@damage 4d6}) damage, or half that if the target succeeds on a {@dc 13} Dexterity saving throw. The cyst's damage is fire, lightning, or piercing (equal chances for each sphere)."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Amphibious"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Swallow"
+      ],
+      "damageTags": [
+        "A",
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "conditionInflict": [
+        "blinded",
+        "prone",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Arric frogs are wide-bodied amphibians with lumpy flesh, cold eyes, and metallic teeth. They hunt living prey in the deeps and shallows and on the coast, and they scavenge for small pieces of metal they can swallow.",
+              {
+                "type": "entries",
+                "name": "Spawning Cysts",
+                "entries": [
+                  "As they grow and age, arric frogs develop egg-like biomechanical cysts within their bodies, adjacent to the stomach. Eventually these cysts erupt into the stomach, the beast vomits one forth, and the cyst sheds its outer layer of protective skin to reveal an {@footnote arric sphere with mechanical and fleshy parts|Use stats for type two basic automaton, with fly 30 ft.|Basic automaton, page 246}, which then flies off. Sometimes this process fails and the arric frog retains these cysts for years, which become quite painful. Eventually the tortured creature drags itself out of the water in search of relief, attacks anything it can reach, and dies, at which point the cysts finally erupt and the newborn arric spheres can finally scatter."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Beast Mounts",
+                "entries": [
+                  "An arric frog can be trained as a mount and ridden with a wide saddle. The rider may use a special goad that encourages the frog to eject an explosive cyst."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "A slain Arric Frog might have one or two biomechanical cysts inside its body, which can be harvested for cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_148_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_148_Image_0002.png"
+    },
+    {
+      "name": "Astraphin Monolith",
+      "source": "AotA",
+      "page": 147,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 19,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 102,
+        "formula": "12d8 + 48"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 0,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 18,
+      "dex": 6,
+      "con": 18,
+      "int": 3,
+      "wis": 10,
+      "cha": 3,
+      "save": {
+        "str": "+7",
+        "con": "+7"
+      },
+      "skill": {
+        "perception": "+2"
+      },
+      "senses": [
+        "darkvision 120 ft.",
+        "tremorsense 120 ft."
+      ],
+      "passive": 13,
+      "resist": [
+        "bludgeoning",
+        "poison"
+      ],
+      "immune": [
+        "necrotic",
+        "poisoned"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "stunned"
+      ],
+      "cr": "8",
+      "trait": [
+        {
+          "name": "Plant Mind",
+          "entries": [
+            "The floating monolith is a construction of the astraphin plant growing on the ground all around it, often stretching for hundreds of feet in all directions. Even a small portion of the plant is enough to control the monolith, so unless the characters are able to completely destroy all plant life in the area, attacking or controlling plants won't end the threat of the monolith. The monolith itself is not a plant and is therefore immune to effects that only work on plants."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The astraphin monolith uses two eye blasts."
+          ]
+        },
+        {
+          "name": "Eye Blast",
+          "entries": [
+            "The monolith shoots energy out of its eye, choosing one of the following effects:",
+            "Force Blast: A creature within 200 feet must make a {@dc 15} Dexterity saving throw, taking 36 ({@damage 8d8}) force damage on a failed save, or half as much damage on a successful one.",
+            "Psychic Blast: A creature within 200 feet must make a {@dc 15} Intelligence saving throw, taking 27 ({@damage 6d8}) psychic damage on a failed save, or half as much damage on a successful one.",
+            "Paralysis Blast: A creature within 200 feet must succeed on a",
+            "{@dc 15} Constitution saving throw or be {@condition paralyzed}. The target can attempt another saving throw every round at the end of their turn to free themselves from this effect.",
+            "Heat Wave: This sweeping ray of heat affects creatures within 10 feet, which take 7 ({@damage 2d6}) fire damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "SD",
+        "T"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "F",
+        "O",
+        "Y"
+      ],
+      "tokenUrl": "",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "An astraphin monolith is a floating, immobile obelisk of stone standing a bit taller than a human, with a single crystalline eye. The eye can create dangerous blasts at long range, leading some to believe it is a hostile earth elemental creature. However, the stone is neither living nor sentient, but rather the extension of a concealed intelligece.",
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "I once made the mistake of thinking this creature was some kind of stone elemental. The monolith ignored our druid friend’s attempts to speak with it, and instead used its psychic blasts to turn his brain into jelly."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Yet another reason I hate plant monsters."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Hidden Plant",
+                "entries": [
+                  "Originally, astraphin was a type of  sometimes fertilized its poor mountain soil by trapping and killing small creatures. In ages past, an unknown energy infused the astraphin, causing it to mutate and develop new abilities, including a simple intelligence. Now it can  and vines, making subtle changes in th a stone monolith over weeks or months. A fully formed monolith springs from the ground to float 10 to 15 feet (3 to 4.6 m) in the air. The plant controls this monolith, using it to kill larger prey and feeding on the corpses through its extensive root system. Destroying the monolith doesn’t harm the plant (it’s equivalent to trimming a fingernail), but it is a setback that takes the plant a while to remedy."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Immovable Destroyer",
+                "entries": [
+                  "An astraphin monolith does not move from its position. It can rotate in place, but apparently doesn’t have the ability to move laterally (or perhaps it can only move very slowly, a matter of inches per day). Because the monolith can’t pursue its opponents, running away is a viable survival strategy, although its incredible range often allows it to dispatch fleeing prey. Some greedy explorers choose to fight a monolith in the hopes of claiming its valuable crystal eye."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Monolith Eye",
+                "entries": [
+                  "The astraphin monolith’s crystalline eye is prized because it can be used as a weapon or a power source for a depleted relic. If used as a weapon, it fires a blast of force at one creature within 200 feet. On a failed DC 15 Dexterity saving throw, the target takes 5d8 force damage. The eye has a depletion of 1–3 in 1d100 when used this way.",
+                  "A character can attach the eye to a depleted relic by spending one hour and making a DC 15 Intelligence (Arcana) check. If successful, the relic functions again and has a depletion of 1 in 1d6; failure means the character makes a depletion roll for the eye (1 in 1d6, checked each attempt). Once connected to a relic, if the relic depletes again, so does the monolith eye."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "In addition to looting a slain monolith’s eye as treasure, the area around it usually has several decaying creatures in the soil, which might have carried cyphers (typically 1d3 cyphers are found)."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_149_Image_0003.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_149_Image_0003.png"
+    },
+    {
+      "name": "Beastcoat Infiltrator",
+      "source": "AotA",
+      "page": 149,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 71,
+        "formula": "11d8 + 22"
+      },
+      "speed": {
+        "walk": 60,
+        "climb": 30,
+        "swim": {
+          "number": 40,
+          "condition": "(as appropriate for its current disguise)"
+        }
+      },
+      "str": 16,
+      "dex": 14,
+      "con": 14,
+      "int": 8,
+      "wis": 12,
+      "cha": 10,
+      "skill": {
+        "athletics": "+5",
+        "deception": "+2",
+        "perception": "+3",
+        "stealth": "+3",
+        "survival": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "4",
+      "trait": [
+        {
+          "name": "Keen Hearing and Smell",
+          "entries": [
+            "The beastcoat infiltrator has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+          ]
+        },
+        {
+          "name": "Limited Beast Disguise",
+          "entries": [
+            "A beastcoat infiltrator can alter its external shape by telescoping its limbs and expanding the plates on its outer surface, but at best this is only a rough approximation. Even when covered in grown animal flesh, it looks more like an animatronic puppet than a real creature, which is usually sufficient to fool other animals. It can vary its size category from a Small to a Medium creature, but this does not affect its stats, and it doesn't assume a radically larger or smaller size that a typical specimen of what it's imitating (it wouldn't become a Small seskii or a Medium ravage bear)."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The beastcoat infiltrator makes two or three attacks, typically bites and claws, as appropriate for the animal it is emulating. If encountered without a disguise, or if it thinks it will be destroyed, it may use an electrical stun attack in place of one of its melee attacks."
+          ]
+        },
+        {
+          "name": "Bite or Claw",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}7 ({@dice 1d8 + 3}) piercing or slashing."
+          ]
+        },
+        {
+          "name": "Electrical Stun",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range 30 ft., one target. {@h}7 ({@damage 2d6}) lightning damage plus the target must succeed on a {@dc 13} Constitution saving throw or fall {@condition unconscious} for one minute."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Keen Senses"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "L"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "conditionInflict": [
+        "unconscious"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Many automatons were built to wage war, for mundane tasks, or for unknowable purposes, but it seems that some were made to understand other things. Examples of the latter are beastcoat infiltrators—adaptive machines that study common animals, learn their behavior, reshape themselves to match their subjects, and cover themselves with harvested or grown flesh (including fur, feathers, or scales) to infiltrate the creatures they are studying.",
+              {
+                "type": "entries",
+                "name": "Just Another Animal",
+                "entries": [
+                  "Beastcoat infiltrators adapt to the social structure of a type of animal or beast (such as deer, tigers, or even ravage bears) and become part of the group. They have been seen aiding a hunt, bringing food back to the lair, helping to raise animal offspring, and otherwise contributing to the welfare of the group while continuing their observations. After weeks, months, or years, the infiltrator leaves to repeat the process with a different group of animals."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Maintaining the Role",
+                "entries": [
+                  "Beastcoat infiltrators either quietly track and observe animals or pretend to be a particular kind of animal, making sure its behavior does not confuse or alarm the living animals it associates with. A character who can communicate with machines might coax it into a limited communication."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "An infiltrator can be salvaged for a couple of cyphers or perhaps a relic. Instead of a relic, PCs may be able to loot its data core, which, if they are able to access the information within it, can be used as a book about animal biology."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_151_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_151_Image_0002.png"
+    },
+    {
+      "name": "Blood Barm",
+      "source": "AotA",
+      "page": 150,
+      "size": "S",
+      "type": "beast",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 33,
+        "formula": "6d6 + 12"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 14,
+      "dex": 15,
+      "con": 14,
+      "int": 7,
+      "wis": 12,
+      "cha": 8,
+      "skill": {
+        "perception": "+3",
+        "stealth": "+4",
+        "survival": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Martial Advantage",
+          "entries": [
+            "Once per turn, the blood barm can deal an extra 7 ({@damage 2d6}) damage to a creature it hits with an attack if that creature is within 5 feet of another blood barm that isn't {@condition incapacitated}."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Spew Explosive Blood Bubble",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range 15/30 ft., one creature. {@h}9 ({@damage 2d6 + 2}) piercing damage. The target must succeed on a {@dc 12} Constitution saving throw or a seed from one of the blood bubbles is implanted in a target's skin for 1 minute, during which time the target suffers 1 point of damage per round. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+          ]
+        },
+        {
+          "name": "Blood Sac Birth {@recharge}",
+          "entries": [
+            "Barms can break their own body sacs by pressing them against a PC or an object. The larger sacs burst first due to their extended size, and any young barms (1-4) within are born. Treat each youngling as a tiny blood barm with 31 hit points that lacks this ability."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Its long neck craning this way and that, the four-footed blood barm doesn’t have an easily distinguishable head or eyes. Instead, a barm has a large opening at the end of its neck covered with a clear membrane similar to an eyelid. The creature’s body, somewhat turkey-shaped, is covered with myriad vesicles rather than feathers, ranging in color from dark green to gray to crimson. These bubbles are filled with liquid and hard seeds. Some seeds have “sprouted,” and these sacs swell with tiny, unborn barms. When the young are close to hatching, the sacs can grow half as large as the barm itself.",
+              {
+                "type": "entries",
+                "name": "Defensive Flocking.",
+                "entries": [
+                  "Blood barms often move about in flocks of two to four. They are not aggressive unless their young are threatened. However, if a flock of barms and their young are located in or near a site the PCs need to access, they might attack."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_152_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_152_Image_0002.png"
+    },
+    {
+      "name": "Bowg",
+      "source": "AotA",
+      "page": 151,
+      "size": "M",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 11,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 65,
+        "formula": "10d8 + 20"
+      },
+      "speed": {
+        "walk": 30,
+        "climb": 30
+      },
+      "str": 13,
+      "dex": 12,
+      "con": 16,
+      "int": 6,
+      "wis": 10,
+      "cha": 8,
+      "skill": {
+        "arcana": "+0 (+2 for mind linked Bowgs)",
+        "perception": "+2"
+      },
+      "senses": [
+        "darkvision 30 ft."
+      ],
+      "passive": 12,
+      "cr": "1/4",
+      "trait": [
+        {
+          "name": "Built to Serve",
+          "entries": [
+            "A bowg has disadvantage on saving throws to resist psychic or machine attempts to control their minds."
+          ]
+        },
+        {
+          "name": "Mindlinked Advantage",
+          "entries": [
+            "Once mental or machine contact or control with a bowg is established, the bowg's Intelligence increases to 9 for the duration of the contact and for approximately 10 minutes thereafter. This gives it a +2 bonus on attack rolls, Intelligence checks, and Intelligence saving throws."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "A wild bowg makes two attacks, usually two claws or a claw and a bite. A mindlinked bowg uses weapons like greatclubs and shortbows, and may be equipped with a cypher by its master."
+          ]
+        },
+        {
+          "name": "Bite or Claw",
+          "entries": [
+            "{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing or slashing damage."
+          ]
+        },
+        {
+          "name": "Greatclub",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d8 + 1}) bludgeoning damage. (This includes the mindlinked bowg's +2 bonus on attack rolls.)"
+          ]
+        },
+        {
+          "name": "Shortbow",
+          "entries": [
+            "{@atk rw} {@hit 5} to hit, range 80/320 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage. (This includes the mindlinked bowg's +2 bonus on attack rolls.)"
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RNG",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "These two-legged pseudoprimates have prominent teeth, four arms (two organic, two metallic), and large mechanical sockets on their backs.",
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "If my clan had ever spied one of these creeping around the Delve back in the day, we would have left no tunnel unfired to burn them out."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Wild Bowgs.",
+                "entries": [
+                  "A typical bowg has the intelligence of a smart animal, such as an ape. They use animalistic tactics and are likely to flee if outmatched. They avoid unknown creatures unless they are very hungry or sense the presence of a mind- or machine-talker—it is not uncommon for wild bowgs to follow a humanoid with these abilities at a distance, subconsciously hoping for the contact that will make them smarter."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Mindlinked Bowgs.",
+                "entries": [
+                  "A bowg’s sockets make them receptive to commands from intelligent machines and psychic entities, turning them into compliant servants for entities that lack the ability to manipulate objects directly. Bowgs thrive on and seek out this contact,as it improves their own ability to think, deduce, and plan, making them almost on par with a typical human. These bowgs use manufactured weapons and better battle tactics (especially if their master gives them instructions about what to do in combat). Mindlinked bowgs are loyal to their master if well-treated (which may make them friendly or hostile toward explorers), but are not willing to harm themselves or others of their kind."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "In addition to psychic creatures and machines with the ability to talk to other machines, bowgs are similarly receptive to mental contact from numenera (such as an eye of mental contact) andcharm spells, as well as machine-based contacts (such as from a mask of machine speaking)."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage.",
+                "entries": [
+                  "The undamaged sockets of a pack of several bowgs might be salvaged for a couple of cyphers. Mindlinked bowgs also may carry conventional equipment and cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_153_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_153_Image_0002.png"
+    },
+    {
+      "name": "Callerail",
+      "source": "AotA",
+      "page": 152,
+      "size": "H",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 180,
+        "formula": "19d12 + 57"
+      },
+      "speed": {
+        "walk": 40
+      },
+      "str": 21,
+      "dex": 14,
+      "con": 16,
+      "int": 7,
+      "wis": 15,
+      "cha": 18,
+      "save": {
+        "dex": "+7",
+        "con": "+9",
+        "wis": "+7",
+        "cha": "+9"
+      },
+      "senses": [
+        "blindsight 60 ft.",
+        "darkvision 120 ft."
+      ],
+      "passive": 12,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "poisoned"
+      ],
+      "cr": "14",
+      "trait": [
+        {
+          "name": "Absorbing Form",
+          "entries": [
+            "A creature that touches the callerail takes 4 ({@damage 1d8}) acid damage, as matter is transferred from the object to the callerail; the callerail regains 4 ({@dice 1d8}) hit points."
+          ]
+        },
+        {
+          "name": "Legendary Resistance (1/Day)",
+          "entries": [
+            "If the callerail fails a saving throw, it can choose to succeed instead."
+          ]
+        },
+        {
+          "name": "Monstrosity's Sight",
+          "entries": [
+            "Magical darkness doesn't impede the callerail's darkvision."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The callerail has advantage on saving throws against spells and other magical effects."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The callerail makes three attacks: one with its bite, and two with bludgeoning limbs to make slam attacks."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d6 + 5}) piercing damage plus 10 ({@damage 3d6}) acid damage.",
+            "In addition, the callerail regains 10 ({@dice 3d6}) hit points."
+          ]
+        },
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d4 + 5}) bludgeoning damage plus 10 ({@damage 3d6}) acid damage. In addition, the callerail regains 10 ({@dice 3d6}) hit points. o receive a foe's attack, and the attack automatically hits.",
+            "The attacking foe must succeed on a {@dc 17} Dexterity saving throw or their weapon is absorbed into the callerail. Whether the saving throw is successful (and the weapon is retained) or not, the attack fails to inflict damage on the callerail. If a nonmagical weapon is absorbed, the callerail regains 10 ({@dice 3d6}) hit points, and the weapon is destroyed. If a magical weapon is absorbed, it becomes part of the callerail; to retrieve it, the callerail must be destroyed.",
+            "The callerail could choose to regain hit points simply by absorbing portions of what's around it, and absorb a 5-foot- cube of nonmagical wood, stone, or metal (or helpless flesh, whether alive or dead). When it does, it regains 10 ({@dice 3d6}) hit points."
+          ]
+        }
+      ],
+      "legendary": [
+        {
+          "name": "Attack",
+          "entries": [
+            "The callerail makes one slam attack."
+          ]
+        },
+        {
+          "name": "Move",
+          "entries": [
+            "The callerail moves up to half its speed."
+          ]
+        },
+        {
+          "name": "Seize (Costs 2 Actions)",
+          "entries": [
+            "The callerail makes one Object Absorption attack."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Legendary Resistances",
+        "Magic Resistance"
+      ],
+      "senseTags": [
+        "B",
+        "SD"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "A",
+        "B",
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A callerail is a creature of fused organic and inorganic substances. Flesh mingles with wood, steel, and stone, as the callerail possesses the ability to absorb inorganic matter and add the material to its body. The creature is a lumbering giant—15 feet tall—that walks using its forelimbs as well as its shorter rear legs. Its body is a conglomeration of materials.",
+              "A callerail’s organic portions remain cohesive so that its circulatory system reaches all areas of its body. It still requires food—in fact, it requires even more food than an ordinary creature of its size.",
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "If you took a demonic ape, gave it the appetite of a bulette, and added in a rust monster’s hunger for metal, that would be a reasonable approximation of a callerail. We are very lucky that they are solitary and aggressive toward their own kind."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "If we’re just making stuff up, I say like the tarrasque had a baby with an iron golem and was raised by a tribe of orc barbarians."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Unreasoning Monstrosity.",
+                "entries": [
+                  "Unreasoning Monstrosity. Reasoning with a hungry callerail is impossible, and they’re always hungry. However, a smart character can fool them by setting a trap, creating a diversion, or using a similar type of tactic. They are not particularly bright and act on animal instinct in most situations."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Focused on Dominance.",
+                "entries": [
+                  "Callerails move into an area and threaten the entire region. Two callerails in the same locale pose a danger to every living thing. The monsters fight to the death, each attempting to absorb the inorganic portions of the other and destroying everything that gets in their way. Afterward, the victor reproduces asexually."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_154_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_154_Image_0002.png"
+    },
+    {
+      "name": "Chirog",
+      "source": "AotA",
+      "page": 154,
+      "size": "M",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "chirog"
+        ]
+      },
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 16,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 90,
+        "formula": "12d8 + 36"
+      },
+      "speed": {
+        "walk": 30,
+        "climb": 30
+      },
+      "str": 16,
+      "dex": 12,
+      "con": 16,
+      "int": 10,
+      "wis": 8,
+      "cha": 8,
+      "skill": {
+        "arcana": "+2",
+        "perception": "+2"
+      },
+      "passive": 11,
+      "languages": [
+        "Chirog",
+        "Common"
+      ],
+      "cr": "4",
+      "trait": [
+        {
+          "name": "Sure-Footed",
+          "entries": [
+            "The chirog has advantage on Strength and Dexterity saving throws made against effects that would knock it {@condition prone}."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}17 ({@damage 4d6 + 3}) piercing damage."
+          ]
+        },
+        {
+          "name": "Grapple",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one Medium or smaller creature. {@h}The creature is {@condition grappled} (escape {@dc 13}). Until this grapple ends, the target is {@condition grappled} and {@condition restrained}, and the chirog can't grapple or bite another target."
+          ]
+        }
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "grappled",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Chirogs are vaguely reptilian humanoids with thick armor plates covering much of their body. They live to hunt and kill, but despite their savage nature, they are craftier and more intelligent than most savage humanoids. They {@footnote understand the numenera||Optional Rule: Intelligence (Ancients Arcana), page 259} and despise it. Even more than killing, they enjoy destroying devices of the ancient past. (Perhaps it is racial resentment for {@footnote wrongs done to them long ago|Chirogs might be mutant offshoots of what are now kobolds, lizardfolk, or even dragonkin.}.) Chirogs are hateful and angry, but not impossible to reason with. They speak their own simple language, and about one in three can speak or understand another language (typically Common or one used nearby). Chirogs do not use weapons or tools.",
+              {
+                "type": "entries",
+                "name": "Corrupt Families",
+                "entries": [
+                  "Each chirog pack has a clear leader who is usually a female, and is likely the mother of many members of the pack. The creatures have a tangled, incestuous relationship, and mature females eventually leave to form a new pack, sometimes taking a brother or two with them."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Among the Trees and Rocks",
+                "entries": [
+                  "Chirogs live in small groups of three to six, usually in wooded areas or rocky, mountainous regions. Because they are adept at climbing, they often build nests or hovels in high branches or on cliff faces where other creatures cannot easily see or reach them."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_156_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_156_Image_0002.png"
+    },
+    {
+      "name": "Cragworm",
+      "source": "AotA",
+      "page": 155,
+      "size": "G",
+      "type": "monstrosity",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 201,
+        "formula": "13d20 + 65"
+      },
+      "speed": {
+        "walk": 50
+      },
+      "str": 20,
+      "dex": 10,
+      "con": 21,
+      "int": 2,
+      "wis": 8,
+      "cha": 4,
+      "save": {
+        "con": "+9",
+        "wis": "+3"
+      },
+      "senses": [
+        "blindsight 30 ft.",
+        "tremorsense 60 ft."
+      ],
+      "passive": 13,
+      "cr": "9",
+      "trait": [
+        {
+          "name": "Easily Deceived",
+          "entries": [
+            "A cragworm is particularly easy to fool if food is involved. They have been known to chase after a fleeing horse and ignore a group of travelers that remain very still until it leaves the area. Cragworms have disadvantage on Intelligence checks to recognize a deception when easily- acquired food is available."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The cragworm's attacks are treated as if magical."
+          ]
+        },
+        {
+          "name": "Stone Camouflage",
+          "entries": [
+            "A cragworm has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}19 ({@damage 4d6 + 5}) piercing damage, and the target must make a {@dc 17} Constitution saving throw, taking 35 ({@damage 10d6}) poison damage on a failed save, or half as much damage on a successful one. If the target is a Large or smaller creature, it must succeed on a {@dc 17} Dexterity saving throw or be swallowed by the cragworm. A swallowed creature is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the worm, and it takes 10 ({@damage 3d6}) acid damage at the start of each of the cragworm's turns.",
+            "If the cragworm takes 20 damage or more on a single turn from a creature inside it, the cragworm must succeed on a {@dc 17} Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall {@condition prone} in a space within 10 feet of the cragworm. If the cragworm dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 20 feet of movement, exiting {@condition prone}."
+          ]
+        },
+        {
+          "name": "Howl {@recharge 5}",
+          "entries": [
+            "Before it emerges to attack, the cragworm howls, reverberating in the audible and subsonic ranges. Each creature within 120 feet of the cragworm must make a {@dc 17} Constitution save. Success means the creature is {@condition paralyzed} for one round, or two rounds for a failed save."
+          ]
+        }
+      ],
+      "actionTags": [
+        "Swallow"
+      ],
+      "damageTags": [
+        "A",
+        "I",
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW",
+        "RCH"
+      ],
+      "conditionInflict": [
+        "blinded",
+        "paralyzed",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A cragworm is a spiny serpent-like creature that can grow up to 50 feet long. It dwells in abandoned or isolated areas, preying on whatever it can find, and eating plants only when starving.",
+              {
+                "type": "entries",
+                "name": "Feeding Its Hunger",
+                "entries": [
+                  "A cragworm has the intelligence of an animal and the outlook of a predator. It can’t be reasoned with, but if confronted before it attacks with a sufficient threat or distraction, it can be intimidated or tricked into leaving a group of creatures alone in favor of easier targets. Once it starts fighting, it only stops if it is killed or there is no prey within sight."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Strange Anatomy",
+                "entries": [
+                  "A cragworm’s mouth opens horizontally, and it has many rows of teeth to help it trap and swallow prey. It has many red, glistening eyes, usually arranged in clusters along the length of its body, but the ones that aren’t near its head are only good for spotting movement, and it will turn its head to bring its best eyes to bear on its prey."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_157_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_157_Image_0002.png"
+    },
+    {
+      "name": "Crith",
+      "source": "AotA",
+      "page": 156,
+      "size": "S",
+      "type": "aberration",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 49,
+        "formula": "9d6 + 18"
+      },
+      "speed": {
+        "walk": 30,
+        "climb": 15,
+        "swim": 15
+      },
+      "str": 12,
+      "dex": 12,
+      "con": 14,
+      "int": 2,
+      "wis": 8,
+      "cha": 6,
+      "save": {
+        "con": "+4"
+      },
+      "senses": [
+        "darkvision 30 ft."
+      ],
+      "passive": 9,
+      "resist": [
+        "bludgeoning"
+      ],
+      "immune": [
+        "necrotic",
+        "poison"
+      ],
+      "conditionImmune": [
+        "poisoned",
+        "prone"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Absorb Nutrients",
+          "entries": [
+            "A crith feeds by absorbing nutrients through its host's skin. A creature hosting a crith starts each day with one fewer Hit Die than normal. (For example, a",
+            "3rd-level fighter with a crith only has two {@dice d10}s they can spend to recover hit points from resting each day.) A creature that normally only has 1 Hit Die will die in its sleep within a day of becoming a crith's host."
+          ]
+        },
+        {
+          "name": "Bonded Gift",
+          "entries": [
+            "A crith's host is immune to poison damage and diseases."
+          ]
+        },
+        {
+          "name": "Immune to Disease",
+          "entries": [
+            "A crith is immune to diseases."
+          ]
+        },
+        {
+          "name": "Nightmares",
+          "entries": [
+            "The crith's bond with its host causes terrible nightmares of strange places and creatures. Although this isn't enough to prevent the character from gaining the benefit of rest, the host is {@condition frightened} for one hour after waking (the source of its fear is internal and doesn't have to be within line of sight). These nightmares even affect hosts that meditate in a trance instead of sleeping."
+          ]
+        },
+        {
+          "name": "Strong Bond",
+          "entries": [
+            "Once bonded, a crith doesn't want to let go, and it sinks tiny barbs into its host's flesh to maintain its grip. To tear off a bonded crith, the host (or someone helping them) must make a {@dc 17} Strength saving throw. Each failed attempt deals 7 ({@damage 2d6}) slashing damage to the host, and a successful attempt deals 14 ({@damage 4d6}) slashing damage to the host, and removes it.",
+            "These actions do not harm the crith, which is likely to attack whatever is trying to remove it from its host."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Tendrils",
+          "entries": [
+            "{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}8 ({@damage 2d6 + 1}) slashing damage and the target must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} for one round."
+          ]
+        },
+        {
+          "name": "Parasitic Bond",
+          "entries": [
+            "The crith bonds to a helpless or willing creature it can touch. It can only bond to one creature at a time."
+          ]
+        },
+        {
+          "name": "Poison Spray {@recharge}",
+          "entries": [
+            "The crith releases a fine mist in a 10-foot-radius sphere. All creatures in the sphere must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} for one round.",
+            "Because this depletes its ability to poison with its tendrils until the ability recharges, a crith normally only uses this ability to escape when it otherwise would be killed."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "S"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "conditionInflict": [
+        "paralyzed"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A crith is a lump of ebony, fleshy material about 2 feet in diameter when inactive. However, it can roughly mimic the shape of any creature it touches, though only in miniature. Other times, it moves by forming legs or arms as needed to run or climb.",
+              {
+                "type": "entries",
+                "name": "Parasitic",
+                "entries": [
+                  "Criths feed by skin-to-skin contact, absorbing nutrients directly. When a crith finds a {@footnote victim|A Large creature might be host to two or more criths.}, it adheres itself to the creature, taking on the appearance of a child-sized silhouette of the larger victim, which it attempts to embrace. In return for nutrition from this embrace, a crith provides certain advantages, but the bond also gives the host bizarre {@footnote nightmares|Sometimes the nightmares that crith hosts endure show locations that actually exist, or at least used to. Likewise with the strange creatures these nightmares sometimes include.}. For most creatures, the nightmares become bad enough that they decide to remove the crith, which is a painful task."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_158_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_158_Image_0002.png"
+    },
+    {
+      "name": "Cuiddit",
+      "source": "AotA",
+      "page": 157,
+      "size": "T",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        17
+      ],
+      "hp": {
+        "average": 54,
+        "formula": "12d4 + 24"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "swim": 30,
+        "canHover": true
+      },
+      "str": 3,
+      "dex": 14,
+      "con": 14,
+      "int": 13,
+      "wis": 14,
+      "cha": 8,
+      "save": {
+        "dex": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "prone"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Obvious",
+          "entries": [
+            "A cuiddit's constant noise and flashing lights means it always fails Stealth checks. Any of its companions within 10 feet have disadvantage on Stealth checks."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Force Fields",
+          "entries": [
+            "Although it doesn't have limbs, a cuiddit can extend two translucent fields of force from itself to manipulate objects within 5 feet. These force fields use the cuiddit's Strength and Dexterity scores. It can also combine these two limbs to create a force field barrier (up to a 10-foot square) or simple solid objects of force that could fit within a 10-foot cube, such as a table, ladder, or ramp. It might use a barrier to prevent a foe of its companions from entering a room, or block an escape route for its own companions."
+          ]
+        },
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 2}) bludgeoning damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "B"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A cuiddit is a levitating sphere, not quite as large as a human head, made of crystal and some hard opaque substance. Images in light play across the surface—sometimes images of a face (though never the same one twice), other times of random, odd scenes or objects. Sounds also constantly trickle from the cuiddit—tinkling or booming, cacophonous or melodic, familiar or utterly alien. Usually found completely inert, it might be mistaken for an oddity or useless junk until it suddenly awakens and—once some form of communication is established—seems determined to offer its aid.",
+              {
+                "type": "entries",
+                "name": "Limited Communication",
+                "entries": [
+                  "A cuiddit doesn’t speak any known language, but it seems to react to communication by changing its images and sounds in response to questions and statements. Even telepathic communication gives these enigmatic responses that are subject to the speaker’s interpretation. Sometimes explorers feel like they are beginning to understand a cuiddit’s reactions by interpreting them depending on the context, but whether they really do understand or are just fooling themselves is up for debate."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Erratic Helper",
+                "entries": [
+                  "When a cuiddit notices other creatures, it begins to follow them around until it is destroyed or driven away. At first, those being followed might appreciate the aid a cuiddit provides. But eventually, they may grow tired of the light show and incessant sounds. Eventually a cuiddit betrays its companions, but it is unknown whether this is a deliberate and malicious act, a misunderstood response to its companion’s actions, or simply erratic programming. This betrayal might be as simple as pushing a character off a ledge, attracting the attention of a nearby monster, or blocking a path of escape."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The remains of a cuiddit can be salvaged for one or two cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_159_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_159_Image_0002.png"
+    },
+    {
+      "name": "Culova",
+      "source": "AotA",
+      "page": 158,
+      "size": "M",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 38,
+        "formula": "7d8 + 5"
+      },
+      "speed": {
+        "walk": 30,
+        "climb": 30
+      },
+      "str": 15,
+      "dex": 15,
+      "con": 12,
+      "int": 10,
+      "wis": 13,
+      "cha": 13,
+      "skill": {
+        "climb": "+5",
+        "perception": "+3"
+      },
+      "passive": 13,
+      "languages": [
+        "Culova",
+        "a few know Common"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Ambusher",
+          "entries": [
+            "The culova has advantage on attack rolls against any creature it has surprised."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Spiked Club",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}13 ({@damage 3d6 + 2} piercing damage."
+          ]
+        },
+        {
+          "name": "Javelin",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range 30/120 ft., one target. {@h}13 ({@damage 3d6 + 2} piercing damage."
+          ]
+        },
+        {
+          "name": "Poison Spray {@recharge}",
+          "entries": [
+            "The culova sprays venom from its mouth, turning its head almost 360 degrees, affecting up to eight targets within 10 feet. Each creature affected must make a {@dc 13} Dexterity saving throw, taking 7 ({@damage 2d6}) poison damage on a failed save, or half as much damage on a successful one.",
+            "Other culovas are immune to this venom."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Ambusher"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "I"
+      ],
+      "miscTags": [
+        "MW",
+        "RW",
+        "THW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Culovas are {@spidery humanoids|Culovas might be a mutant offshoot of a creature like an ettercap, or ettercaps might be near- humanoid mutations of ancient culovas.} with eight spindly legs, a bulbous midsection, and a pair of human-like arms with three fingers. Eight eyes adorn their heads like colored beads above disturbingly broad, toothy mouths. They move with astonishing quickness.",
+              {
+                "type": "entries",
+                "name": "Forest Hunters",
+                "entries": [
+                  "Although they look monstrous, culovas are usually peaceful creatures that live in small groups deep within a forest, hunting for food and caring for their young. They lead simple lives and have little interest in building large structures. Unlike most spidery creatures, culovas do not make webs."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Territorial",
+                "entries": [
+                  "Culovas avoid contact with other intelligent creatures unless they or their territories are threatened. They repel groups of intelligent creatures (such as marauding humanoids or people who want to log their forests) with weapons and their venom."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Elusive",
+                "entries": [
+                  "Culovas do not leave familiar ground except in extraordinary circumstances, so they are always on the defensive, even when they launch an attack. However, an attacking culova can be reasoned with. If they can be convinced that an intruder is not a threat or that they’ll cease being a threat—which usually involves leaving the area—they might be willing to let their opponents leave peacefully."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "Very rarely, a culova might have a cypher. They never have other treasure or things that a human might find valuable."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_160_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_160_Image_0002.png"
+    },
+    {
+      "name": "Cynoclept",
+      "source": "AotA",
+      "page": 159,
+      "size": "L",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 127,
+        "formula": "15d10 + 45"
+      },
+      "speed": {
+        "walk": 30,
+        "climb": 30
+      },
+      "str": 16,
+      "dex": 12,
+      "con": 16,
+      "int": 8,
+      "wis": 8,
+      "cha": 8,
+      "skill": {
+        "arcana": "+3",
+        "perception": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "resist": [
+        "fire",
+        "lightning"
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "9",
+      "trait": [
+        {
+          "name": "Cypher Sense",
+          "entries": [
+            "A cynoclept automatically senses the presence of all cyphers within 60 feet unless the cyphers are behind a force field."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The cynoclept's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The cynoclept makes two limb attacks and uses its activate cypher ability. If a limb hits, the cynoclept can use steal and repair against the same target."
+          ]
+        },
+        {
+          "name": "Limb",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d8 + 3}) bludgeoning, piercing, or slashing damage."
+          ]
+        },
+        {
+          "name": "Activate Cypher",
+          "entries": [
+            "As a bonus action, a cynoclept can activate a cypher within 10 feet (whether held by another creature or merely in the area) as if it were holding the cypher. If the cypher is in the possession of another creature, that creature can resist this attempt with a successful {@dc 13} Intelligence saving throw."
+          ]
+        },
+        {
+          "name": "Steal and Repair",
+          "entries": [
+            "An injured cynoclept can grab a cypher and add the device to its own body, repairing 30 points of damage.",
+            "If this takes it over its normal hit point total, it gains the excess amount as temporary hit points. If the targeted cypher is in the possession of another creature, that creature can resist this grab attempt with a successful {@dc 13} Strength or Dexterity saving throw."
+          ]
+        },
+        {
+          "name": "Psychic Trap",
+          "entries": [
+            "Approximately 10% of cynoclepts are made of amber crystal that is psionically reactive to the mental energy of most humanoids. For these cynoclepts, if their attempt to activate an opponent's cypher succeeds, the opponent's mind temporarily becomes trapped in the cynoclept's body for one minute and its body falls {@condition unconscious}. The only Intelligence saving throw each round on their turn, with a success returning the passenger to their own body. Killing the cynoclept  automatically returns a trapped passenger's mind to their own body."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A thick outer shell of amber crystal protects the cynoclept, so it has little to fear. The shell grows as the creature accumulates cyphers and other special numenera components. Initially not much larger than a human’s fist, it eventually grows to be 6 feet in diameter, at which time it begins to openly roam locations where cyphers might be found, or if the opportunity arises, it follows explorers who’ve recently looted cyphers from a location it was watching.",
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Remember when that tiefling wizard thought he tamed one of these things? He even rode around on it like a giant turtle and fed it little cyphers as treats."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Yes, and I remember the day he used a mind-augmenting cypher that grafted itself to his head, and the cynoclept decapitated him and ran off with it—the cypher, with his head still attached."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Negotiable Manace",
+                "entries": [
+                  "Cynoclepts are clever, and though they don’t speak a language, they can be negotiated with through pictures drawn on the ground, pantomime, or sign language. They are motivated by finding more cyphers or salvaged amber crystal."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Cannibal",
+                "entries": [
+                  "Although a cynoclept’s primary diet is cyphers, when they meet others of their kind (including the rarely-seen smaller, younger forms), they attempt to eat and absorb their fellows, giving and receiving no quarter."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The wreck of a cynoclept’s body can be salvaged for about six cyphers."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "When characters exceed their cypher limit, cynoclepts can spontaneously form from the interaction, robbing the character of their belongings and creating a dangerous threat in the same instant."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_162_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_162_Image_0002.png"
+    },
+    {
+      "name": "Cypherid",
+      "source": "AotA",
+      "page": 161,
+      "size": "S",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 27,
+        "formula": "6d6 + 6"
+      },
+      "speed": {
+        "walk": 30,
+        "climb": 10
+      },
+      "str": 13,
+      "dex": 14,
+      "con": 13,
+      "int": 3,
+      "wis": 8,
+      "cha": 5,
+      "skill": {
+        "perception": "+1"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 11,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Cypher Sense",
+          "entries": [
+            "A cypherid automatically senses the presence of all cyphers within 60 feet unless the cyphers are behind a force field."
+          ]
+        },
+        {
+          "name": "Swarm Targeting",
+          "entries": [
+            "If four or more cypherids attack the same target, each cypherid gains advantage on its attack roll, and their opponents have disadvantage on saving throws against the incorporated cypher ability."
+          ]
+        },
+        {
+          "name": "Numenera Camouflage",
+          "entries": [
+            "The cypherid has advantage on Dexterity (Stealth) checks made to hide in numenera ruins and amist other pieces of the numenera, including scrap."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The cypherid makes one attack with its blade. If that attack hits, the cypherid can use steal and repair against the same target."
+          ]
+        },
+        {
+          "name": "Blade",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 1}) piercing or slashing damage. If the target has any cyphers, the cypherid can use its steal and repair ability."
+          ]
+        },
+        {
+          "name": "Activate Incorporated Cypher {@recharge}",
+          "entries": [
+            "If a cypherid feels especially threatened, it activates one of the cyphers incorporated into its body. This is usually one of the following effects:",
+            "• Destructive ray (one target within 120 feet takes 12 ({@damage 3d8}) fire damage unless they succeed on a {@dc 13} Dexterity saving throw)",
+            "• Lightning burst (everything in a 5-foot-radius sphere takes 14 ({@damage 4d6}) lightning damage, or half that if they succeed on a {@dc 13} Dexterity saving throw)",
+            "• Gravity wave (everything in a 5-foot-radius sphere is knocked {@condition prone} and takes 10 ({@damage 3d6}) bludgeoning damage, or half that if they succeed on a {@dc 13} Dexterity saving throw)",
+            "• Phase changer (allows the cypherid to escape by moving through solid objects for one minute)",
+            "Alternatively, the GM can create other offensive, defensive, or utilitarian cypher-like effects similar to the above, with a {@dc 13}."
+          ]
+        },
+        {
+          "name": "Steal and Repair",
+          "entries": [
+            "The cypherid extends a glassy tendril into the targeted character's equipment and attempts to steal one cypher and add the device to its own body. If the cypherid is injured, this repairs 7 points of damage. If this takes it over its normal hit point total, it gains the excess amount as temporary hit points. The target can resist this grab attempt with a successful {@dc 13} Strength or Dexterity saving throw."
+          ]
+        },
+        {
+          "name": "Spawn {@recharge}",
+          "entries": [
+            "A group of four cypherids can focus on a target who carries two or more cyphers, causing the cyphers to fuse together and animate as a new cypherid. The target can prevent this from happening with a {@dc 13} Intelligence saving throw. The character has disadvantage on this saving throw because of the cypherid's swarm targeting ability."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "F",
+        "L",
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "conditionInflict": [
+        "prone"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Cypherids are automatons that are essentially {@footnote an animate accumulation of cyphers|Some people familiar with the numenera speculate that cypherids are a simpler progenitor of a cynoclept, presumably having found a permanent way to maintain its intellect.|Cynoclept, page 159}. Like vermin, they sometimes conglomerate in ruins. They flit, clamber, slide, or trundle along on limbs made of disparate devices, though there is an overall spider-like body structure to the creature. A cypherid generally doesn’t reach dimensions larger than a couple of feet across. Like an insect, a cypherid seems driven by simple motives. In this case, it is to accumulate more cyphers to add to itself as older components get used up or burn out.",
+              {
+                "type": "inset",
+                "entries": [
+                  "Some sages of the numenera believe cypherids could be a primitive kind of cynoclept, perhaps one that hasn’t acquired any amber crystal to form a protective shell. Other suggest that cypherids are the animate remnants of a destroyed cynoclept trying to restore their original form."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Intermittently Intelligent",
+                "entries": [
+                  "Most cypherids are not intelligent and do not communicate. A few that absorb cyphers that allow them to communicate with other machines (or similar abilities) can gain intelligent behaviors and advanced motives, for a time. Such a creature that gains, loses, and gains intelligence again likely realizes the fragility of its higher functioning and focuses its efforts on acquiring more cyphers that can prevent it from again lapsing into a beast-like state."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "One to three cyphers can be salvaged from a cypherid’s body."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_164_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_164_Image_0002.png"
+    },
+    {
+      "name": "Dabirri",
+      "source": "AotA",
+      "page": 163,
+      "size": "S",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 8,
+        "formula": "2d6 + 1"
+      },
+      "speed": {
+        "swim": 10
+      },
+      "str": 6,
+      "dex": 10,
+      "con": 11,
+      "int": 1,
+      "wis": 5,
+      "cha": 1,
+      "senses": [
+        "blindsight 30 ft."
+      ],
+      "passive": 7,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "blinded",
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "prone"
+      ],
+      "cr": "1/4",
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The dabirri makes two tendril sting attacks."
+          ]
+        },
+        {
+          "name": "Tendril Sting",
+          "entries": [
+            "{@atk mw} {@hit 2} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d8}) necrotic damage. If the attack is a critical hit, the jolt of disrupting energy hops to another creature within 5 feet and deals 4 ({@damage 1d8}) necrotic damage to that creature."
+          ]
+        }
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "N"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A dabirri is an artificial water-dwelling construct created by taking the heart of a human-sized creature and placing it in a hard transparent shell. A dabirri does not eat and is not intelligent, but it instinctively attacks warm-blooded creatures with its venomous tendrils. A typical specimen is anywhere from 1 to 3 feet across, with the tendrils adding an additional length all around equal to the body’s diameter. It moves by a combination of fine jets of water and swimming with its tendrils.",
+              {
+                "type": "entries",
+                "name": "Deadly Sting",
+                "entries": [
+                  "Unlike a jellyfish, a dabirri’s sting isn’t poisonous. Instead, it jolts its opponent with a pulse of energy that transmits a signal that tells the target’s cells to shut down and die. Although its individual attacks are weak, they tend to be found in swarms, and the aggregate effect of these stings can eventually overwhelm even large targets."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Fabricated Entity",
+                "entries": [
+                  "Although it has living components, a dabirri cannot reproduce. Presumably, another, larger creature or numenera structure continues to produce them by harvesting the hearts of suitable creatures."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Within the central portion of a Dabirri is a tiny dollop of a useful chemical that restores 1 point of damage if injected or taken internally."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_165_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_165_Image_0002.png"
+    },
+    {
+      "name": "Dark Fathom",
+      "source": "AotA",
+      "page": 164,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 20,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 190,
+        "formula": "20d8 + 100"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 14,
+      "dex": 10,
+      "con": 20,
+      "int": 12,
+      "wis": 14,
+      "cha": 10,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 18,
+      "resist": [
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks"
+        }
+      ],
+      "immune": [
+        "necrotic",
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "17",
+      "trait": [
+        {
+          "name": "Consume Ranged Attacks",
+          "entries": [
+            "The dark fathom's singularity automatically draws in and consumes all ranged attacks directed at it, whether they are matter (such as arrows and crossbow bolts) or energy (including numenera rays and spell effects like scorching ray and disintegrate). The creature suffers no harm from these attacks. The only ranged attacks it can't absorb are mental (such as phantasmal killer), magnetic energy, or extradimensional."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The dark fathom's attacks are treated as if magical."
+          ]
+        },
+        {
+          "name": "Gravity Field",
+          "entries": [
+            "Any creature within 5 feet of a dark fathom must succeed on a {@dc 19} Strength saving throw at the start of their turn. Those who fail are partially drawn into the singularity and take 22 ({@damage 5d8}) force damage. Characters reduced to 0 hp from this damage are completely drawn into the singularity, consumed, and utterly destroyed."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Singularity Pull",
+          "entries": [
+            "A dark fathom can use its singularity to pull all creatures and objects within 30 feet toward it so they end up next to it. Creatures can resist this pull with a successful {@dc 19} Strength saving throw."
+          ]
+        },
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}12 ({@damage 3d6 + 2}) bludgeoning damage."
+          ]
+        }
+      ],
+      "reaction": [
+        {
+          "name": "Absorb (Recharge 5-6)",
+          "entries": [
+            "As its reaction, by using the force of its singularity, a dark fathom can attempt to pull in and absorb an object or energy source within 10 feet, so long as its target is smaller than itself. For example, it might absorb a door blocking its way, a stone from a catapult launched at it, or the power core of a numenera structure. If the target is an object, it takes 45 ({@damage 10d8}) force damage; if this reduces the object to 0 hit points, it is disintegrated by the dark fathom's singularity. If the target is an energy source, roll {@dice 10d8} and subtract this result from the damage the energy source deals; if this reduces the energy source's damage to 0, it is completely destroyed by the singularity. After the dark fathom uses this ability, on its next turn it cannot use its singularity for anything."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "B",
+        "O"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A dark fathom looks like a darkly armored humanoid with a black hole in the center of its chest, surrounded by a vortex of swirling energy—or perhaps the black hole is its chest, and the creature is built around that empty space. The rest of its body is completely obscured by its armor and helmet. Part mechanical and part biological, a dark fathom is an engine of destruction from aeons past, pursuing a solitary mission that only it understands.",
+              {
+                "type": "entries",
+                "name": "Singularity Heart",
+                "entries": [
+                  "The swirling hole in a dark fathom’s chest is an artificial singularity, an area of gravity so intense that matter and energy cannot escape it. This is the creature’s power source and a {@footnote devastating weapon|Sometimes when a dark fathom uses its singularity pull, the strain temporarily overwhelms it, stunning it on its next turn.}. Anyone nearby can feel a slight current of air pulling toward the creature, and it is common to see small pieces of debris and even tiny creatures pulled into the singularity and destroyed."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Although a dark fathom’s singularity resembles a sphere of annihilation, the singularity is an area of intense gravity, whereas the sphere is a magical hole in the universe. If the GM wants to mix magic and technology, certain things that affect the sphere might have a similar effect on the dark fathom. For example, holding a talisman of the sphere might give a character a round-by-round chance to control the dark fathom for a short time, pushing the dark fathom into a gate or portable hole might create a spatial rift, and so on. The dark fathom almost certainly would recognize the risks of these attacks and attempt to kill or absorb the source of the threat."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Inscrutable",
+                "entries": [
+                  "A dark fathom is difficult to interact with. Although very intelligent, it doesn’t seem to understand any spoken languages. However, telepathy (whether the kind that works on living creatures or machine telepathy from a numenera device) allows characters to communicate with it and perhaps even to reason with it. A dark fathom can be bribed to move on instead of fighting, but it is interested only in exotic matter and energies (or information about where those things can be found). Some dark fathoms have their own agendas or interests as well, but their motive is always destruction, and that makes them dangerous."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "A dark fathom has mechanical and biomechanical parts that can be salvaged for {@dice 1d6} + 4 cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_167_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_167_Image_0002.png"
+    },
+    {
+      "name": "Deadeye",
+      "source": "AotA",
+      "page": 166,
+      "size": "H",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 195,
+        "formula": "17d12 + 85"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 10,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 18,
+      "dex": 10,
+      "con": 21,
+      "int": 20,
+      "wis": 15,
+      "cha": 13,
+      "save": {
+        "con": "+9",
+        "int": "+9",
+        "wis": "+6",
+        "cha": "+5"
+      },
+      "skill": {
+        "perception": "+6"
+      },
+      "senses": [
+        "darkvision 60 ft.",
+        "truesight 30 ft."
+      ],
+      "passive": 16,
+      "resist": [
+        "bludgeoning",
+        "piercing",
+        "slashing"
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "12",
+      "trait": [
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The deadeye's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Psychic Onslaught",
+          "entries": [
+            "The deadeye projects psychic energy against up to three creatures within 60 feet or one creature within 120 feet. Each creature takes 28 ({@damage 8d6}) psychic damage, or half that with a successful {@dc 17} Intelligence saving throw."
+          ]
+        },
+        {
+          "name": "Teleport",
+          "entries": [
+            "A deadeye can teleport to anywhere within about",
+            "1,000 miles. It also seems to have the ability to travel several hours into the past of its current location and then return to the true present when it wants to."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D",
+        "U"
+      ],
+      "actionTags": [
+        "Teleport"
+      ],
+      "damageTags": [
+        "Y"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A deadeye — also known as a gravewatcher — is a 20-foot-diameter machine that takes great interest in the deaths of intelligent living things. It isn’t a murderer, unless forced to defend itself. Instead, it shows up right after one or more people have been killed to view the remains for several minutes, deploying an array of strange devices over the bodies. Sometimes, it appears before a lethal situation arises, as if it somehow knows that deaths are imminent. Wherever and whenever it is, a deadeye is always watching, always recording.",
+              {
+                "type": "entries",
+                "name": "Strange Announcements",
+                "entries": [
+                  "When a deadeye shows up prior to a death (as opposed to afterward), it sometimes speaks using the tone, intonation, words, and knowledge of a creature whose remains it has previously recorded. Such pronouncements at first sound inane and without context. However, the meaning sometimes becomes clear as later events play out, when the mysterious message is revealed to have been a warning. Often, that realization comes too late. Rarely, it has been known to speak with the voice of someone that a person present knows to be dead, which can be very disturbing."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Non-aggressive",
+                "entries": [
+                  "A deadeye never initiates an attack but will defend itself. It persists in this onslaught only if those attacking it continue their own attacks. If overmatched, a deadeye teleports away, potentially also moving some hours into the past."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The remains of a gravewatcher contains {@dice 1d6} cyphers, {@dice 1d10} oddities, and {@dice 1d2} relics."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_168_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_168_Image_0002.png"
+    },
+    {
+      "name": "Disassembler",
+      "source": "AotA",
+      "page": 167,
+      "size": "L",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 104,
+        "formula": "11d10 + 44"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 19,
+      "dex": 15,
+      "con": 18,
+      "int": 14,
+      "wis": 13,
+      "cha": 13,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 14,
+      "resist": [
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks"
+        }
+      ],
+      "immune": [
+        "poison",
+        "psychic"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "understands most languages after hearing them for a few minutes"
+      ],
+      "cr": "5",
+      "trait": [
+        {
+          "name": "Inorganic Destruction",
+          "entries": [
+            "The dissembler sometimes turns artificial objects and portions of structures it can see within 5 feet of it into liquid and gas (destroying them). If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature is subject to one or more Disassembly Claw attacks; on a hit, instead of dealing damage, the object is affected as follows.",
+            "If the object touched is unliving armor or a shield being worn or carried, it takes a permanent and cumulative -1 penalty to the AC it offers (some magical armor and shields shed this penalty within a day, unless destroyed). Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held nonliving weapon, the weapon takes a permanent and cumulative -1 penalty to damage rolls (magical weapons shed this penalty within a day, unless destroyed). If its penalty drops to -5, the weapon is destroyed."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The disassembler makes three attacks with its disassembly claws. If a target is wearing nonliving armor or wielding a nonliving weapon (such as armor and weapons made of iron), it makes one, two, or three attacks that affect objects as described in the Inorganic Destruction trait. (The other one or two attacks against the target affect it as a normal attack.)"
+          ]
+        },
+        {
+          "name": "Disassembly Claws",
+          "entries": [
+            "{@atk m} {@hit 7} to hit, reach 5 ft., one target. {@h}11 ({@damage 2d6 + 4}) piercing damage, or 21 ({@damage 5d6 + 4}) piercing damage if attacking a creature composed of inorganic or nonliving matter (such as most constructs and undead)."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "AOE"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A disassembler is a strange-looking artificial creature of glass and steel with six spindly metallic arms arranged around its circular midsection. Its upper half is all glaring green lights and mechanical protrusions, some of which might be sensory mechanisms. Its lower half is a broad engine that allows it to hover 3 feet off the ground. If it landed, the disassembler would be about 8 feet tall.",
+              {
+                "type": "entries",
+                "name": "Mad Wanderers",
+                "entries": [
+                  "Disassemblers are artificially intelligent automatons that seem to have gone mad at some point. Now they act erratically—sometimes attacking creatures, sometimes ignoring them, sometimes destroying what they come across, sometimes wandering aimlessly.",
+                  "A conversation with a disassembler is possible. They understand speech and, after listening to a language for a time, can often speak it in a very basic way. But the creature is just as likely to attack without provocation, perhaps in the middle of a conversation. Still, a well-spoken, intelligent, and quick-witted character might be able to figure out what a disassembler wants (at the moment) and convince it not to attack or perhaps to do something to aid them."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Potential Predators of the Living",
+                "entries": [
+                  "The construct’s disassembling tools cannot affect organic matter, but this limitation might have been programmed into it—perhaps as a safety mechanism—rather than being a true inability. A disassembler with this prohibition removed would be a terror."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_170_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_170_Image_0002.png"
+    },
+    {
+      "name": "Dissector",
+      "source": "AotA",
+      "page": 169,
+      "size": "L",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 142,
+        "formula": "15d10 + 60"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 20,
+      "dex": 15,
+      "con": 18,
+      "int": 17,
+      "wis": 14,
+      "cha": 14,
+      "save": {
+        "con": "+8",
+        "int": "+7"
+      },
+      "skill": {
+        "medicine": "+6",
+        "nature": "+7",
+        "perception": "+6"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 16,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "several",
+        "learns new languages after listening for several minutes"
+      ],
+      "cr": "9",
+      "trait": [
+        {
+          "name": "Ignore Defenses",
+          "entries": [
+            "A dissector can create specialized microtools that allow it to slice through and store any kind of organic tissue, as well as physical materials that are blocking access to its test subject. Its attacks ignore the AC granted by physical armor, but not from magic or force fields. Its attacks deal full damage against fleshy targets, even if the target would normally have resistance or immunity to bludgeoning, piercing, or slashing damage."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The dissector's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The dissector makes two manipulator attacks."
+          ]
+        },
+        {
+          "name": "Manipulator",
+          "entries": [
+            "{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}50 ({@damage 10d8 + 5}) piercing or slashing damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "This bulky artificial creature sports thick metallic arms articulated with stubby manipulators. Its lower body is a metallic tripod that gives the creature the ability to hover just above any solid surface or fly rapidly to distant locations. Dissectors are entirely motivated by the study of life itself. However, that study is apparently not grounded in respect, because their method of study requires that they completely dissect every organ of each new subject they acquire. Often, those organs are neatly embedded in metal containers. Of the original donor, nothing remains but parts.",
+              {
+                "type": "entries",
+                "name": "Surgical Tools",
+                "entries": [
+                  "Each of a dissector’s manipulators is able to extrude a nanite scaffolding of far smaller instruments that can be selectively tuned to disrupt and cut flesh, limbs, organs, or other tissues within living creatures. Though it selects subjects and dissects them to death, it works on only one subject at a time and may take some time before selecting a new target, which means it doesn’t attack every living thing it comes across."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Negotiable Research",
+                "entries": [
+                  "Though single-minded, a dissector maybe willing to negotiate if the PCsoffer to lead it to a brand-newkind of subject that it has neverpreviously studied. The dissectormight insist that the PCs allow itto extract one “unneeded” organfrom someone present, otherwisethe talk is concluded."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The remains of a destroyed dissector might hold {@dice 1d6 + 1} cyphers, an oddity, and perhaps a relic."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_171_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_171_Image_0002.png"
+    },
+    {
+      "name": "Dread Destroyer",
+      "source": "AotA",
+      "page": 170,
+      "size": "G",
+      "type": "construct",
+      "alignment": [
+        {
+          "alignment": [
+            "N"
+          ],
+          "note": "or as programmed"
+        }
+      ],
+      "ac": [
+        {
+          "ac": 25,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 676,
+        "formula": "33d20 + 330"
+      },
+      "speed": {
+        "walk": 40,
+        "climb": 30,
+        "swim": 40
+      },
+      "str": 30,
+      "dex": 10,
+      "con": 30,
+      "int": 14,
+      "wis": 14,
+      "cha": 13,
+      "save": {
+        "int": "+11",
+        "wis": "+11",
+        "cha": "+10"
+      },
+      "skill": {
+        "perception": "+11"
+      },
+      "senses": [
+        "blindsight 120 ft.",
+        "darkvision 120 ft.",
+        "tremorsense 120 ft."
+      ],
+      "passive": 21,
+      "resist": [
+        "fire",
+        "thunder"
+      ],
+      "immune": [
+        "lightning",
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "prone"
+      ],
+      "cr": "30",
+      "trait": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "entries": [
+            "If the dread destroyer fails a saving throw, it can choose to succeed instead."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The dread destroyer has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The dread destroyer's attacks are treated as if magical.",
+            "Self-repair. The dread destroyer automatically repairs 20 hit points at the start of its turn. It is only destroyed if it starts its turn with 0 hit points."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The dread destroyer can fire a missile and electrocute, or make six attacks: four slams, grapple (mandibles), and fire a missile."
+          ]
+        },
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 19} to hit, reach 10 ft., one target. {@h}36 ({@damage 4d12 + 10}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Grapple",
+          "entries": [
+            "{@atk mw} {@hit 19} to hit, reach 10 ft., one target. {@h}17 ({@damage 2d6 + 10}) lightning damage. If the target is a Large or smaller creature, it is {@condition restrained} (escape DC 29) Until this grapple ends, target automatically takes 17 ({@damage 2d6 + 10}) lightning damage every round on the dread destroyer's turn, and the dread destroyer cannot grapple another target."
+          ]
+        },
+        {
+          "name": "Missile",
+          "entries": [
+            "{@atk rw} {@hit 9} to hit, range 500 feet/1 mile, all targets within 100 feet of the impact point. {@h}13 ({@damage 2d10 + 2}) piercing damage plus 13 ({@damage 2d10 + 2}) fire damage; creatures in the blast area who succeed on a {@dc 19} Dexterity saving throw take half damage."
+          ]
+        },
+        {
+          "name": "Electrocute",
+          "entries": [
+            "Each creature within 10 feet of the dread destroyer takes 10 ({@damage 3d6}) lightning damage."
+          ]
+        }
+      ],
+      "legendary": [
+        {
+          "name": "Attack",
+          "entries": [
+            "The dread destroyer makes one slam attack."
+          ]
+        },
+        {
+          "name": "Move",
+          "entries": [
+            "The dread destroyer moves up to half its speed."
+          ]
+        },
+        {
+          "name": "Seize (Costs 2 Actions)",
+          "entries": [
+            "The dread destroyer makes one grapple attack."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Legendary Resistances",
+        "Magic Resistance"
+      ],
+      "senseTags": [
+        "B",
+        "SD",
+        "T"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "F",
+        "L",
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW",
+        "RCH",
+        "RW"
+      ],
+      "conditionInflict": [
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A dread destroyer is likely the most horrific thing on a battlefield. Unless you have an army on your side and are willing to lose a large portion of your forces, battle is unwise. Still, the greatest guardians often protect the greatest treasures. Only one of these automatons has been seen at a time, but holographic images have shown scenes (presumably from the distant past) when hundreds of dread destroyers crawled across a battlefield together. Although a single dread destroyer could launch an attack on an entire city, it is far more likely that you’ll find one defending an important, ancient site.",
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Imagine a tarrasque and a dread destroyer battling each other, two terrible destructive forces in perfect opposition. Their battlefield would quickly become a wasteland, and they might fight for weeks before one gained an advantage over the other."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Makes a drow stronghold seem like a safe place in comparison. I’d bet on the machine, though, it’s got an advantage of range."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Hybrid Construct",
+                "entries": [
+                  "These giant war machines have organic brains and internal organs protected by a self-repairing metal shell. If communication can be established with its organic brain, a PC can reason with a dread destroyer, but convincing it to do something is very difficult, and usually the best option for survival is to flee until it has moved on to some other location."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Aquatic and Land Assault",
+                "entries": [
+                  "Dread destroyers do not need to breathe, and can be encountered on land or underwater. Presumably they might be found in space, but they would require modifications to allow them to maneuver there."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The remains of a dread destroyer are a scavenger’s dream, yielding at least {@dice 1d20} oddities, {@dice 1d20} cyphers, and {@dice 1d6} relics."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_172_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_172_Image_0002.png"
+    },
+    {
+      "name": "Entrope",
+      "source": "AotA",
+      "page": 172,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 76,
+        "formula": "8d10 + 32"
+      },
+      "speed": {
+        "walk": 30,
+        "burrow": {
+          "number": 10,
+          "condition": "(ice and snow only)"
+        }
+      },
+      "str": 17,
+      "dex": 11,
+      "con": 18,
+      "int": 2,
+      "wis": 10,
+      "cha": 5,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "immune": [
+        "cold"
+      ],
+      "vulnerable": [
+        "fire"
+      ],
+      "cr": "5",
+      "trait": [
+        {
+          "name": "Hibernation",
+          "entries": [
+            "An entrope remains active so long as there are suitable heat sources within 10 feet of itself. If no appropriate heat sources are within range, after about a minute it stops moving and begins to hibernate again. If attacked from beyond this range, it struggles to remain awake and has disadvantage on all of its rolls."
+          ]
+        },
+        {
+          "name": "Cold Aura",
+          "entries": [
+            "Upon waking, an entrope generates a heat- absorbing field at immediate range, which also coats all objects and creatures in the area with a thin layer of frost.",
+            "At the start of each of its turns, each creature within 10 feet of it that fails a {@dc 17} Constitution save takes 5 ({@damage 1d10}) cold damage and gains disadvantage on actions that require movement. Cold auras from multiple entropes are additive.",
+            "Creatures with resistance or immunity to cold do not gain disadvantage from the cold aura."
+          ]
+        },
+        {
+          "name": "Detect Heat",
+          "entries": [
+            "An entrope can sense the heat from warm- blooded living creatures up to 60 feet away. It knows the general direction they're in but not their exact locations."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The entrope makes two tentacle attacks."
+          ]
+        },
+        {
+          "name": "Tentacle",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 10 ft., one target. {@h}10 ({@damage 2d6 + 3}) cold damage."
+          ]
+        },
+        {
+          "name": "Spawn",
+          "entries": [
+            "Every point of cold damage the entrope deals is added to its hit points, whether the cold damage is caused by its cold aura or its tentacle attacks. When an entrope absorbs enough heat that its hit point total reaches 100, it spends its action spawning, becoming two entropes, each with half of the single entrope's hit points, rounded down."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack",
+        "Tentacles"
+      ],
+      "damageTags": [
+        "C"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW",
+        "RCH"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "An entrope is an entity made of exotic biomineral that feeds on the heat given off by the bodies of living creatures. When it has absorbed enough heat, it can reproduce. They are usually discovered solo or in pairs, looking like thin statues that are cold to the touch— until they begin moving. An entrope is about 6 feet tall and nearly 15 feet long, but its odd hunched body shape makes it shorter than its actual length.",
+              {
+                "type": "entries",
+                "name": "Hibernation",
+                "entries": [
+                  "An entrope can freeze motionless for years, centuries, or even longer until it detects a suitable heat source. It is unknown why they do not react to other sources of heat such as open flames and volcanic fissures, and is never found in warm environments, under open sky, or underwater. Most are found in subterranean locations, tunnels, and basements. They might be native to frigid regions, but it is more likely that they originated from an icy moon or rogue planet that crashed into the world and scattered them across its surface."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Primite Insticts",
+                "entries": [
+                  "By all appearances, an entrope has animal intelligence at most. Its drives appear to be simple: feed on heat from living creatures, spawn, and repeat."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "Every entrope corpse has an organ called an entropic seed that can be removed and used as a detonation of frost cypher."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_174_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_174_Image_0002.png"
+    },
+    {
+      "name": "Etterick",
+      "source": "AotA",
+      "page": 173,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 127,
+        "formula": "15d8 + 60"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 18,
+      "dex": 10,
+      "con": 18,
+      "int": 13,
+      "wis": 14,
+      "cha": 8,
+      "save": {
+        "str": "+7",
+        "con": "+7",
+        "int": "+4"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 12,
+      "resist": [
+        "bludgeoning"
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "8",
+      "trait": [
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The etterick's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The etterick makes two slam attacks or uses its magnetic pulse."
+          ]
+        },
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}22 ({@damage 4d8 + 4}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Magnetic Pulse {@recharge 4}",
+          "entries": [
+            "The etterick emits a powerful magnetic pulse that deals 18 ({@damage 4d8}) force damage to all creatures within 30 feet, or half that with a successful {@dc 15} Dexterity saving throw. Creatures with a large amount of metal on their person (such as medium or heavy metal armor) must also succeed on a {@dc 15} Strength saving throw or be knocked {@condition prone} and back 10 feet."
+          ]
+        }
+      ],
+      "reaction": [
+        {
+          "name": "Heavyweight",
+          "entries": [
+            "An etterick that is knocked {@condition prone} is 50% likely to fall toward an adjacent opponent. This deals 22 ({@damage 4d8 + 4}) bludgeoning damage, knocks the opponent {@condition prone}, and restrains the opponent with the weight of its body. If the character makes a successful {@dc 15} Dexterity saving throw, they take half damage and are not knocked {@condition prone} or {@condition restrained}. A {@condition restrained} character can free itself as an action by making a {@dc 15} Strength or Dexterity saving throw (character's choice). If the etterick believes this position is to its advantage, it remains {@condition prone}, otherwise it uses its move to stand up on its next turn."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "O"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "prone"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "The thing that people call an etterick is an automaton in the vague shape of a human, with transparent metal skin. Crawling around in its hollow interior is a swarm of insects that look like no other insects found anywhere. They control the machine through means that look like scuttling around and doing typical insect activities. An etterik is 7 to 8 feet tall, but thinner and slightly disproportionate compared to a human. If an etterick is destroyed, the insects inside swarm out and scatter, never to be seen again.",
+              {
+                "type": "entries",
+                "name": "Violent Communicator",
+                "entries": [
+                  "Those who attempt to communicate with an etterick—or rather, with its hive-mind pilots that act as a singular entity— find it quite willing to talk. However, establishing that communication in the first place requires telepathy or a similar ability. The etterick will not (cannot?) share its origins and finds almost any mundane topics or meaningless niceties to be reason to attack. But it is amenable to bribery or straightforward negotiations (such as “We’ll leave this area immediately if you stop attacking us”). It seems to value most numenera items."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "What is it?” Jul nocked another arrow and ducked behind the tree.",
+                      "“Damned if I know.” Marlich whispered. He hid behind a pile of rotting logs.",
+                      "“It looks like glass, but my arrow bounced off it like it was stone.”",
+                      "“Yeah, but what are those things crawling around inside it? Are they trapped in there?”",
+                      "“Look like bugs. Maybe they just crawled in there.”",
+                      "“Or they’re controlling it ... ”",
+                      "“They’re just bugs!”",
+                      "“We’ve seen stranger things.”",
+                      "“I’m not sure we have."
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "Looting through the remains of an etterick yields a bounty of 1d6 + 1 cyphers and a relic, all made of transparent metal."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_175_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_175_Image_0002.png"
+    },
+    {
+      "name": "Ferno Walker",
+      "source": "AotA",
+      "page": 174,
+      "size": "L",
+      "type": "beast",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 135,
+        "formula": "18d10 + 36"
+      },
+      "speed": {
+        "walk": 60
+      },
+      "str": 18,
+      "dex": 10,
+      "con": 16,
+      "int": 2,
+      "wis": 12,
+      "cha": 7,
+      "skill": {
+        "climb": "+7",
+        "perception": "+4"
+      },
+      "passive": 14,
+      "immune": [
+        "fire"
+      ],
+      "cr": "8",
+      "trait": [
+        {
+          "name": "Mountain Agility",
+          "entries": [
+            "The ferno walker ignores difficult terrain resulting from broken, rocky, or steep terrain."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The ferno walker makes two bite attacks, or one bite and uses a held weapon or cypher."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}22 ({@damage 4d8 + 4}) piercing damage."
+          ]
+        },
+        {
+          "name": "Superheated Spew {@recharge 5}",
+          "entries": [
+            "The ferno walker vomits a super-hot liquid chemical in a 10-foot cone or a 30-foot line.",
+            "Each creature in the area must make a {@dc 15} Dexterity saving throw, taking 7 ({@damage 2d6}) acid damage and 7 ({@damage 2d6}) fire damage on a failed save, or half as much damage on a successful one."
+          ]
+        }
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "A",
+        "F",
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Some people speculate that the ferno walker and the snow loper shared a common ancestor in the distant past, both being six-limbed mammals with a pair of usable hands. Regardless, the ferno walker is very different from its possible cousin. These predators supplement their diet of meat by ingesting large stones that sit in a special portion of their gut. Through an unknown process, {@footnote this organ produces extreme temperatures|Tanners and leatherworkers have attempted to use ferno walker skins to make heat-resistant armor, but so far all attempts have failed.}, heating the rocks so that there is a literal furnace in its belly at all times. A ferno walker can go for weeks without water.",
+              {
+                "type": "entries",
+                "name": "Semi-intelligent",
+                "entries": [
+                  "Although ferno walkers do not use language, {@footnote they are more intelligent than they might appear|Some ancient civilization may have created ferno walkers by mixing the genes of creatures like red dragons and rhinoceroses to create a sturdy mount suitable for hot, hilly terrain.}. They are aloof and defensive, but if approached with peace, patience, and bribes of food, they might interact without violence. This is much harder if the ferno walker has young nearby (all persuasion and negotiation attempts have disadvantage)."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Great Mounts",
+                "entries": [
+                  "Ferno walkers are sometimes captured and forced to become mounts. Other times, they befriend a humanoid and willingly become a mount and companion. Most can be trained to use cyphers and other simple devices, and a smart rider equips their mount with a weapon or device that it can use in its hands."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_176_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_176_Image_0002.png"
+    },
+    {
+      "name": "Ganthanhar",
+      "source": "AotA",
+      "page": 175,
+      "size": "M",
+      "type": "elemental",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "containment suit"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 120,
+        "formula": "16d8 + 48"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 14,
+      "dex": 14,
+      "con": 16,
+      "int": 17,
+      "wis": 12,
+      "cha": 11,
+      "save": {
+        "con": "+6",
+        "int": "+6"
+      },
+      "skill": {
+        "arcana": "+6",
+        "perception": "+4"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 14,
+      "resist": [
+        "cold",
+        "fire",
+        "lightning",
+        "radiant"
+      ],
+      "languages": [
+        "Ganthanhar",
+        "various others"
+      ],
+      "cr": "6",
+      "trait": [
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The ganthanhar's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bodiless",
+          "entries": [
+            "A ganthanhar doesn't have a physical body, so it can't use cyphers or other devices that require a living metabolism (such as most pills and injections). They can still manipulate objects, allowing them to use other items (including cyphers and relics)."
+          ]
+        },
+        {
+          "name": "Death Throes",
+          "entries": [
+            "If a ganthanhar's hit points reach 0, its suit ruptures and releases the dying creature's radiation in an explosion. Each creature within 30 feet of it must make a {@dc 14} Dexterity saving throw, taking 14 ({@damage 4d6}) fire damage on a failed save, or half as much damage on a successful one."
+          ]
+        },
+        {
+          "name": "Protective Suit",
+          "entries": [
+            "A ganthanhar's containment suit gives them resistance to cold, fire, lightning, and radiant damage. A desperate, injured ganthanhar can abandon its suit to exist as an independent energy being. Without its suit, a ganthanhar's radiation aura inflicts double damage and its speed increases to 500 feet, but its AC decreases to 10 and it will perish within a few hours if it doesn't get back into its suit."
+          ]
+        },
+        {
+          "name": "Radiation Aura",
+          "entries": [
+            "A ganthanhar constantly emits dangerous radiation out to an immediate distance. At the start of each of the ganthanhar's turns, each creature within 10 feet of it takes 3 ({@dice 1d6}) fire and 3 ({@damage 1d6}) radiant damage. Ganthanhars are immune to their own radiation and that of other ganthanhars."
+          ]
+        },
+        {
+          "name": "Radiation Blast",
+          "entries": [
+            "{@atk rw} {@hit 5} to hit, range 30/60 ft., one target. {@h}21 ({@damage 6d6}) fire damage and 21 ({@damage 6d6}) radiant damage."
+          ]
+        },
+        {
+          "name": "Venting",
+          "entries": [
+            "If a ganthanhar is struck by a critical hit with a melee weapon, radiation from its suit leaks out, damaging the attacker for 3 ({@dice 1d6}) fire and 3 ({@damage 1d6}) radiant damage. If the critical hit is from a ranged weapon, this vented radiation instead strikes an opponent within 5 feet."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "F",
+        "R"
+      ],
+      "miscTags": [
+        "AOE",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Ganthanhars look like four-armed, armored humanoids with digitigrade legs. Where their heads should be is a cloud of swirling energy containing a few mechanical or organic devices resembling eyes.",
+              {
+                "type": "entries",
+                "name": "Ascended Energy Form",
+                "entries": [
+                  "Ganthanhars claim to be a race of advanced beings who experimented with extradimensional energies to make themselves immortal. Their experiments apparently succeeded in some respects, but their bodies have mostly been transformed into energy and they must wear special suits to prevent their physical forms from completely dissipating. Having exhausted all known remedies for their medical condition, they sift through lost civilizations in search of answers."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Arrogant",
+                "entries": [
+                  "Ganthanhars don’t believe that other species have the capability to help with their specific needs. If they see someone using an unfamiliar piece of numenera that they think can help them, they will try to steal it or at least offer to trade for it."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "A ganthanhar’s suit can be salvaged for one or two cyphers and one or two oddities."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_177_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_177_Image_0002.png"
+    },
+    {
+      "name": "Gazer",
+      "source": "AotA",
+      "page": 176,
+      "size": "T",
+      "type": "construct",
+      "alignment": [
+        {
+          "alignment": [
+            "N"
+          ],
+          "note": "or as programmed"
+        }
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 7,
+        "formula": "3d4"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 100,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 6,
+      "dex": 15,
+      "con": 11,
+      "int": 11,
+      "wis": 10,
+      "cha": 7,
+      "save": {
+        "dexterity": "+4"
+      },
+      "skill": {
+        "perception": "+2"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 12,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "prone"
+      ],
+      "cr": "1/8",
+      "trait": [
+        {
+          "name": "Intense Light",
+          "entries": [
+            "Although a gazer's beam only inflicts a small amount of damage, it is capable of cutting through very tough materials, including wood, stone, and steel. A gazer trying to damage an object treats any object AC less than 18 as AC 10."
+          ]
+        },
+        {
+          "name": "Swarm Targeting",
+          "entries": [
+            "If two or more gazers attack the same target, each gazer gains advantage on its attack roll."
+          ]
+        },
+        {
+          "name": "Sharpshooter",
+          "entries": [
+            "A gazer's attacks ignore half cover and three-quarters cover."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Red Beam",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range 100/120 ft., one target. {@h}5 ({@damage 1d6 + 2}) fire damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "F"
+      ],
+      "miscTags": [
+        "RW"
+      ],
+      "tokenUrl": "",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A gazer is a levitating metallic spherical automaton, about 1.5 feet in diameter. Various bits of equipment and blinking lights festoon a gazer’s battered metal-alloy body. A concavity on one side of the sphere incessantly emits a beam of scarlet light. The red beam can intensify in a moment, creating a ray capable of burning through nearly anything.",
+              {
+                "type": "entries",
+                "name": "Flying Tactics",
+                "entries": [
+                  "Groups of gazers fly in a spherical formation, which allows them to present the maximum possible perception and threat surface. Depending on the locations of their opponents, they may arrange themselves around or in the middle of their foes. Formations of six to twelve gazers might be found defending ancient ruined installations. Sometimes a lone gazer is encountered as a companion of a creature who reprogrammed it to act as a servitor."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Old Programming",
+                "entries": [
+                  "A gazer usually interacts only by flashing its beam in coded bursts, accompanied by eerie bleats of electronic static. Most active gazers follow a program to defend a location, reconnoiter a wider area, or seek and destroy those who match profiles held in their machine brains. However, if any group of gazers is interfered with too much, they attempt to eradicate the perceived threat."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Legacy of Ancient War",
+                "entries": [
+                  "Gazers are speculated to be antiques of a forgotten war that were originally {@footnote forged by the millions|Some explorers have reported caches of sphere- shaped numenera that turn out to be destroyed gazers. Often, a few of these automatons are still active...}. Only a handful remain active. However, if one of the ancient warehouses were discovered, that number could radically increase."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "A swarm of six to twelve gazers may be salvaged for up to 1d6 cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_178_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_178_Image_0002.png"
+    },
+    {
+      "name": "Glaxter",
+      "source": "AotA",
+      "page": 177,
+      "size": "L",
+      "type": "aberration",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 152,
+        "formula": "16d10 + 64"
+      },
+      "speed": {
+        "walk": 30,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 16,
+      "dex": 10,
+      "con": 18,
+      "int": 16,
+      "wis": 15,
+      "cha": 16,
+      "save": {
+        "con": "+7",
+        "int": "+6"
+      },
+      "skill": {
+        "arcana": "+6",
+        "anythreeknowledgeskills": "+6"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 12,
+      "resist": [
+        "bludgeoning"
+      ],
+      "conditionImmune": [
+        "grappled",
+        "prone",
+        "restrained"
+      ],
+      "languages": [
+        "Common",
+        "several others"
+      ],
+      "cr": "8",
+      "trait": [
+        {
+          "name": "Amorphous",
+          "entries": [
+            "The glaxter can move through a space as narrow as 4 inches wide without squeezing."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The glaxter's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The glaxter can make up to three pseudopod attacks, but prefers to fire two telekinetic bolts at range."
+          ]
+        },
+        {
+          "name": "Pseudopod",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}21 ({@damage 4d8 + 3}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Telekinetic Bolt",
+          "entries": [
+            "{@atk rw} {@hit 6} to hit, range",
+            "30/100 ft., one target. {@h}27 ({@damage 6d8}) force damage."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Amorphous"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "B",
+        "O"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Glaxters are sentient collections of eye-studded chunks of flesh, able to rearrange their overall shape as needed. When at rest, they look like a mound of lumpy, odd-colored flesh with bright crystalline eyes all over. When active, they assume either a floating spheroid shape or (when interacting peacefully with humanoids) {@footnote something approximating a large humanoid form|Were the ancient ancestors of glaxters creatures like gibbering mouthers? Or are gibbering mouthers the degenerate mutated cousins of glaxters?}, with either form often orbited by small discrete pieces of itself.",
+              {
+                "type": "entries",
+                "name": "Malleable",
+                "entries": [
+                  "Although not completely fluid, a glaxter’s component pieces are the size of a human fist, and a glaxter can pass through any barrier that its smallest piece can move through, such as through a pipe or between the bars of a prison cell."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Parts of a Whole",
+                "entries": [
+                  "When pieces of a glaxter are in direct contact with each other, nerve tissue on the surface automatically connects them and lets the unified pieces act as one entity. They can separate smaller pieces ({@footnote remote nodules|Use stats for basic automaton, type one, two, or three (depending on its size), except with the aberration type.|Basic automaton page 246}), programming them with simple instructions and reconnecting later to absorb the disconnected pieces’ memories."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Social Blob",
+                "entries": [
+                  "laxters communicate audibly by telekinetically vibrating the air to create the sound of words. Each glaxter has its own areas of interest—botany, social structure, thermodynamics, and so on—and observes things to further their knowledge. Multiple glaxters in the same place often exchange nodules (they do not explain whether this is communication or mating). They sometimes send out remote nodules with instructions to find interesting creatures and lead them back to its main body (so it can discuss a research proposition) or to test their reactions."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Klowledgeable and Noisy",
+                "entries": [
+                  "Glaxters present themselves as dispassionate but curious observers of the creatures and locations of the world. They prefer to watch rather than interact. When they decide they are done observing and ready to leave, they may choose to answer questions about their areas of knowledge. One may follow a group of PCs for hours or days, all the while insisting that the characters should act normally, as if it wasn’t there, so it can observe their behavior or the functioning of a specific pie"
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "A glaxter’s large bulk can be salvaged for 1d6 cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_179_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_179_Image_0002.png"
+    },
+    {
+      "name": "Gleresisk",
+      "source": "AotA",
+      "page": 178,
+      "size": "S",
+      "type": "aberration",
+      "alignment": [
+        {
+          "alignment": [
+            "U"
+          ],
+          "note": "or neutral evil when intelligent"
+        }
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 64,
+        "formula": "16d6 + 16"
+      },
+      "speed": {
+        "walk": 5,
+        "fly": {
+          "number": 60,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 8,
+      "dex": 16,
+      "con": 12,
+      "int": 3,
+      "wis": 13,
+      "cha": 4,
+      "save": {
+        "intelligence": "-2"
+      },
+      "skill": {
+        "perception": "+3"
+      },
+      "passive": 13,
+      "immune": [
+        "bludgeoning"
+      ],
+      "languages": [
+        "none",
+        "or as its most recently consumed mind"
+      ],
+      "cr": "4",
+      "action": [
+        {
+          "name": "Tendrils",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}17 ({@damage 5d6}) psychic damage. If the target is Medium or smaller, it is {@condition grappled} (escape {@dc 13})."
+          ]
+        },
+        {
+          "name": "Extract Brain",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one {@condition incapacitated} humanoid {@condition grappled} by the gleresisk. {@h}17 ({@damage 5d6}) psychic damage. If this damage reduces the target to 0 hit points, the gleresisk kills the target by extracting and absorbing its brain. The gleresisk then releases its opponent, which falls {@condition prone}, dead.",
+            "A typical humanoid brain of Intelligence 7 to 13 increases the gleresisk's Intelligence to 13 for about a day. Less- or more- intelligent brains make the glerisisk less or more intelligent for this period of time.",
+            "If more than one gleresisk is grappling a creature when it dies from this ability, all of them absorb a portion of the creature's brains and intellect, forming a fragmented collective mind.",
+            "A gleresisk can extract the brain of a creature that died from something other than its attacks, but doing so means it retains its heightened intellect for a much shorter time depending on how long the creature had been dead—approximately halving the duration for every 10 minutes the creature was dead before its brain was extracted (half a day after 10 minutes, one-fourth of a day after 20 minutes, and so on)."
+          ]
+        }
+      ],
+      "damageTags": [
+        "Y"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "grappled"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "This head-sized mass of yellowish floating goo has blubbery, foam-like flesh and a parade of trailing tendrils. It might be mistaken for a seed pod of a particularly large plant blowing in the wind—until it turns against the wind and dives for newly-perceived prey. Gleresisks can be found alone or in drifting flocks of three to ten.",
+              {
+                "type": "entries",
+                "name": "Mind Eater",
+                "entries": [
+                  "A gleresisk absorbs minds by physically sucking brain matter into itself. The victim’s knowledge and memories become the gleresisk’s. When it eats a mind, it becomes a conscious and intelligent creature for one day, during which time it can plan, pick up previously conceived projects, and so on, until it metabolizes the stolen brain tissue and once again reverts to a predator with merely animal instincts."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Deceptive Absorption",
+                "entries": [
+                  "A gleresisk can mimic speech and even act with the motivations of someone’s mind who was recently consumed, but that’s just a ruse. It has its own agenda, which probably involves methods of securing future minds on which to feed in relative safety."
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "If you dream that your mind was absorbed by a gleresisk, how do you know if it’s really a dream, or merely the last thoughts of your absorbed brain?"
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_180_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_180_Image_0002.png"
+    },
+    {
+      "name": "Golthiar",
+      "source": "AotA",
+      "page": 179,
+      "size": "M",
+      "type": "plant",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 52,
+        "formula": "8d8 + 16"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 17,
+      "dex": 10,
+      "con": 15,
+      "int": 10,
+      "wis": 10,
+      "cha": 7,
+      "save": {
+        "str": "+5",
+        "wis": "+2"
+      },
+      "skill": {
+        "climb": "+5",
+        "perception": "+2"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 12,
+      "resist": [
+        "bludgeoning",
+        "piercing"
+      ],
+      "vulnerable": [
+        "fire"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Regeneration",
+          "entries": [
+            "A golthiar regains 10 hit points at the start of its turn if it has at least 1 hit point and is in direct sunlight."
+          ]
+        },
+        {
+          "name": "Flash Sensitivity",
+          "entries": [
+            "Unexpected exposure to bright light is disorienting for a golthiar. The first time it is exposed to a flash of bright light during an encounter, it must make a Wisdom saving throw against the light's DC (or {@dc 11} for a source without a DC). Failure means the golthiar is {@condition incapacitated} on its next turn."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The golthiar makes a spear attack with one arm and a bash attack with its other one."
+          ]
+        },
+        {
+          "name": "Spear",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) piercing damage."
+          ]
+        },
+        {
+          "name": "Bash",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Light Blast {@recharge}",
+          "entries": [
+            "About one in four golthiars have the ability to create a burst of light that affects all opponents within 30 feet. Each creature affected must make a {@dc 12} Dexterity saving throw, taking 9 ({@damage 2d6 + 2}) radiant damage on a failed save, or half as much damage on a successful one."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Regeneration"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "P",
+        "R"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Golthiars are humanoid creatures of woody muscle and bark-like skin that smell of sap. Their bulbous heads each have only a single eye surrounded by a fringe of jagged petals. They are quick and brutal despite their plant ancestry. A golthiar stands about 6.5 feet tall. Golthiars usually act as part of a team, coordinating their attacks through squirts of beamed color that is invisible to most people. The creatures direct the beams at each other or display them on a wall or ceiling that all the golthiars in an area can see.",
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "A bard told me that her see invisibility spell allowed her to see the flashes of light that golthiars use to communicate with each other. She is still working out the nuances of their language, but they appear to be as intelligent as you or I, with a complex vocabulary and nuanced phrasing."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "If you and your bard friend want to talk to plants, that’s on you. Me, I’ll stick to using them as garnish for my meat."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Guardian Sprouts",
+                "entries": [
+                  "{@footnote Golthiars are plants|Golthiars probably come from a deliberate mutated gene added to many different kinds of trees.}, and are planted rather than born. Underground seedpods “ripen” in groups of four to six at a time, push to the surface, and peel open to reveal wet, wrinkly creatures the size of adult humans. Within an hour, the creatures completely mature into soldiers able to survive for centuries on sun and nutrients gathered from burying themselves in soil every few days."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Crafted Growths",
+                "entries": [
+                  "Trees that produce golthiar seedpods are not always similar in appearance. Sometimes they have great fronds, other times needles, and other times leaves. It’s almost as if the {@footnote pods that ripen beneath the ground are not part of the original tree’s growth.|If a defeated golthiar is planted in the ground and carefully tended, a new grove of golthiar saplings may spring up within a few weeks.}"
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "In places where the numenera is active, even plant creatures such as shambling mounds and treants may sprout golthiar pods. Intelligent plant creatures react to this much like humanoids do to maggots in wounds, even though golthiars usually act friendly toward them. Lower-intelligence plant creatures seem to instinctively recognize the resulting golthiars as kin and allies."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Purposeful",
+                "entries": [
+                  "Golthiars not guarding, attacking, or scouting something wither and die within a few months. Those without orders could be willing to find a new command, but communicating with a golthiar requires knowing how to produce and decode the pulsating beams of light preferred by the creatures."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_182_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_182_Image_0002.png"
+    },
+    {
+      "name": "Grey Sampler",
+      "source": "AotA",
+      "page": 181,
+      "size": "L",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 102,
+        "formula": "12d10 + 36"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 20,
+      "dex": 12,
+      "con": 16,
+      "int": 11,
+      "wis": 12,
+      "cha": 10,
+      "skill": {
+        "perception": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "any one"
+      ],
+      "cr": "4",
+      "trait": [
+        {
+          "name": "Charge",
+          "entries": [
+            "If the grey sampler moves at least 30 feet straight toward a target and then hits it with a surgical blades attack on the same turn, the target takes an extra 10 ({@damage 3d6}) piercing damage. The target must succeed on a {@dc 15} saving throw or be pushed back 10 feet and knocked {@condition prone}."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Surgical Blades",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}19 ({@damage 4d6 + 5}) slashing damage."
+          ]
+        },
+        {
+          "name": "Process Brains",
+          "entries": [
+            "As a bonus action, a grey sampler can attempt to remove the brains of an {@condition unconscious}, dead, {@condition paralyzed}, or completely immobilized creature. If the target dies, it extracts the creature's brain and processes it into sludge."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Charge"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "prone"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A grey sampler is a flying automaton with asymmetrical construction, measuring almost 10 feet in diameter. Where its head should be is an angular funnel that roars and vibrates with endless fury. One of its limbs splits into a mess of slicing and scissoring blades. The grey sampler uses this limb to subdue specimens, separate cranial matter from clinging flesh and bone, and deposit the freed brain into its head-funnel. Somewhere in the grey sampler’s chest, the solid matter is processed into pinkish slush. The automaton’s other limb is more like a metallic, hollow tentacle that expels processed cranial matter. Most of the time, the cranial matter is sprayed behind the automaton in a wide, even arc, as if it’s spreading fertilizer or seeds.",
+              {
+                "type": "entries",
+                "name": "Hidden Construction",
+                "entries": [
+                  "Grey samplers have a disconcerting ability to build themselves out of much smaller parts, too tiny to see without the aid of powerful numenera. This means that small fleets of them can arise anywhere, building themselves in secret, until an unknowable signal passes among them, and they emerge for the next harvest."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Determined",
+                "entries": [
+                  "A grey sampler can communicate, but its main interest is directing potential victims to hold still so it can do its job. If asked who gave it the job or what it ultimately wants to accomplish, a grey sampler either doesn’t answer or says, “The fruit of our harvest prepares the way.” If someone who can talk to machines or who is otherwise skilled with numenera devices discovers a fleet of grey samplers building themselves from nearby components, they might be able to direct the fleet to self-destruct by making a DC 17 Intelligence (Arcana) check."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The remains of a destroyed grey sampler might hold a cypher or two."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_183_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_183_Image_0002.png"
+    },
+    {
+      "name": "Griefsteel",
+      "source": "AotA",
+      "page": 182,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "A"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 171,
+        "formula": "18d8 + 90"
+      },
+      "speed": {
+        "walk": {
+          "number": 30,
+          "condition": "(some also have fly 60 ft.)"
+        }
+      },
+      "str": 21,
+      "dex": 12,
+      "con": 20,
+      "int": 12,
+      "wis": 12,
+      "cha": 12,
+      "save": {
+        "str": "+9",
+        "con": "+9"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 15,
+      "resist": [
+        "bludgeoning"
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "one or two ancient languages"
+      ],
+      "cr": "12",
+      "trait": [
+        {
+          "name": "Emotional Feedback",
+          "entries": [
+            "Attempts to mentally communicate with the griefsteel or connect to it with machine ports transmits the full force of its loss and trauma to the communicating creature's mind. The attempting creature must succeed on a {@dc 13} Wisdom saving throw or be {@condition stunned} for one round."
+          ]
+        },
+        {
+          "name": "Gullible",
+          "entries": [
+            "A griefsteel desperately wants to believe anything that will momentarily distract it from its misery. It has disadvantage on rolls to see through disguises or recognize when someone is lying to it. However, once it realizes it has been tricked, it usually becomes angry and tries to harm those who deceived it."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The griefsteel's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The griefsteel makes three claw attacks and uses its energy ray."
+          ]
+        },
+        {
+          "name": "Claw",
+          "entries": [
+            "{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}32 ({@damage 5d10 + 5}) slashing damage."
+          ]
+        },
+        {
+          "name": "Energy Ray",
+          "entries": [
+            "{@atk rw} {@hit 5} to hit, range 60/120 ft., one target. {@h}11 ({@damage 3d6 + 1}) fire damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "F",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A griefsteel is an automaton crafted to serve as a companion and guardian to another creature. However, that creature died ages ago, leaving the machine forever heartbroken. Although they are self-aware and able to learn, their emotion programs sometimes get them stuck in a mental loop from which they’re unable to escape. Whether encountered in the deeps of a lonely ruin or wandering across the empty landscape, a sorrow-wracked griefsteel is unlikely to ever find solace.",
+              {
+                "type": "entries",
+                "name": "Deliberately Solitary",
+                "entries": [
+                  "A griefsteel might first ignore, then wail at someone trying to communicate with it. If communication attempts persist, it will finally strike out at whoever is bothering it, unless the intruder is extremely persuasive and calming."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Unpredictable",
+                "entries": [
+                  "Unending sorrow makes a griefsteel’s behavior erratic. It’s not usually a threat, but it’s also not usually helpful. It’s too lost in its own misery to notice or care about others’ needs. Sometimes, the anguished automaton strikes out in fury over its loss, and an explorer who disrupted its iterative depressive cycle makes a good target—especially those who remind the griefsteel of what it’s lost. There is a chance that a griefsteel mistakenly believes that a character is its long-lost companion, but soon begins to have doubts, which makes it angry. A griefsteel has been known to mistake a stranger for the being who originally built it, and may beg to have its memory wiped or attack because it blames its creator for its sensitive emotional programming."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Many Forms",
+                "entries": [
+                  "Griefsteels have different forms depending on who created them. What is presented here is a typical specimen, but individual griefsteels may have different attacks or special abilities."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "{@dice 1d6} cyphers can be salvaged from a griefsteel’s corpse."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_184_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_184_Image_0002.png"
+    },
+    {
+      "name": "Haneek",
+      "source": "AotA",
+      "page": 183,
+      "size": "M",
+      "type": "aberration",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 120,
+        "formula": "16d8 + 36"
+      },
+      "speed": {
+        "walk": 30,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 5,
+      "dex": 16,
+      "con": 16,
+      "int": 10,
+      "wis": 12,
+      "cha": 8,
+      "save": {
+        "dexterity": "+6"
+      },
+      "skill": {
+        "perception": "+4",
+        "stealth+6(orstealth-3foruptoanhourafterithas": "fed)"
+      },
+      "senses": [
+        "darkvision 30 ft."
+      ],
+      "passive": 14,
+      "resist": [
+        "acid",
+        "piercing"
+      ],
+      "immune": [
+        "bludgeoning"
+      ],
+      "conditionImmune": [
+        "grappled",
+        "prone"
+      ],
+      "cr": "5",
+      "trait": [
+        {
+          "name": "Amorphous",
+          "entries": [
+            "The haneek can move through a space as narrow as 1 inch tall and a few inches wide without squeezing."
+          ]
+        },
+        {
+          "name": "Adhesive",
+          "entries": [
+            "The haneek can automatically adhere to anything that touches it. A Huge or smaller creature adhered to the haneek is also {@condition grappled} by it (escape {@dc 14}). Ability checks made to escape this grapple have disadvantage."
+          ]
+        },
+        {
+          "name": "Grappler",
+          "entries": [
+            "The haneek has advantage on attack rolls against any creature {@condition grappled} by it."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Flesh Flap",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage plus 21 ({@damage 6d6}) acid damage."
+          ]
+        },
+        {
+          "name": "Split",
+          "entries": [
+            "When a haneek that is Medium or larger takes 20 slashing damage or more from a single attack, it splits into two new haneeks if it has at least 15 hit points. Each new haneek has hit points equal to half the original haneek's, rounded down. New haneeks are one size smaller than the original haneek."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Amorphous"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "A",
+        "B"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "grappled"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Haneek are essentially sheets of almost transparent flesh that pass light with hardly any distortion. They can twist and fold themselves to move about like sidewinding snakes, gallop on faux limbs, and can even flap and glide through the air. Regardless of their shape, they smell a bit like rotting food, which is often the only warning those being hunted by a haneek have before the creature drops on them. They have been known to hang from branches or straddle doorways in high-traffic areas so creatures can walk into them.",
+              {
+                "type": "entries",
+                "name": "Visible Digestion",
+                "entries": [
+                  "Once a victim is ensnared by a haneek, flesh-to-tissue contact begins to digest the prey. This sends a bloom of scarlet radiating through the haneek’s body, rendering it briefly visible as it feeds."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Unpredictable Lurker",
+                "entries": [
+                  "A haneek is a hungry predator, but it sometimes “adopts” a character and merely follows them around, rather than trying to eat them. It hunts other creatures around the followed character instead. Because haneek are hard to spot, it’s often not initially apparent what’s going on, and it’s possible for PCs to meet another character who doesn’t realize they’re being followed by a haneek. Haneek seem somewhat intelligent, but they do not communicate or seem to have a language."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_185_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_185_Image_0002.png"
+    },
+    {
+      "name": "Herder",
+      "source": "AotA",
+      "page": 184,
+      "size": "L",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 76,
+        "formula": "9d10 + 27"
+      },
+      "speed": {
+        "walk": 50
+      },
+      "str": 18,
+      "dex": 12,
+      "con": 16,
+      "int": 6,
+      "wis": 14,
+      "cha": 6,
+      "save": {
+        "con": "+5"
+      },
+      "skill": {
+        "perception": "+4"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 14,
+      "resist": [
+        "bludgeoning",
+        "piercing",
+        "slashing"
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "3",
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The herder charges and makes a gore attack, or it makes two claw attacks."
+          ]
+        },
+        {
+          "name": "Charge",
+          "entries": [
+            "If the herder moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 ({@damage 2d8}) piercing damage. If the target is a creature, it must succeed on a {@dc 14} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+          ]
+        },
+        {
+          "name": "Gore",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage, and the target must succeed on a {@dc 14} Constitution saving throw or be {@condition stunned} for one round."
+          ]
+        },
+        {
+          "name": "Claw",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}18 ({@damage 2d10 + 4}) slashing damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "prone",
+        "stunned"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "This mechanical creature looks like a very large insect built of metal pipes and bone-colored ceramic. It bears a semicircle of metal spikes down its back, four sharp claws on each foot, and a hard, bone-like spur on the left side of its head. It stands nearly 3 feet tall, plus another 1 to 2 feet for its spikes.",
+              {
+                "type": "entries",
+                "name": "Gaurdians of Others",
+                "entries": [
+                  "Herders were clearly created by someone or something, possibly for the protection of {@footnote catlike herbivores called enyi|For enyi, use stats for deer. They resemble long-eared, brown panthers.} (or possibly the enyi’s ancestors from thousands of generations in the past). Typically, one or two herders watch over a group of five to ten enyi (or some other nonaggressive herbivore if there are no enyi in the area). Often, one herder will move among the enyi and the other will follow nearby, out of sight, charging into view if combat occurs. Enyi react to herders as if the machines were harmless, perhaps due to a scent, sound, or vibration the herder uses to soothe the animals."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Threat Display",
+                "entries": [
+                  "A herder displays various forms of aggression toward anything that it perceives as threatening its herd. The displays are nearly ritualistic in their order. First, the herder begins to make a loud clacking sound, created by rubbing its hind legs together. Characters often hear this sound long before they are close enough to see the herder; those with knowledge of the creature know to avoid the sound if possible. If the danger doesn’t go away, the herder rises up on its hind legs, doubling its height. The final sign of aggression before a herder attacks is that it drops its head and thumps its ceramic spur against the ground, hard enough for PCs to feel the collision beneath their feet. The first display of aggression is passive and ongoing; the last two each take one round."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Ruthless",
+                "entries": [
+                  "A herder’s main objective is to defend their enyi, but once they begin combat, they don’t stop, even if the enyi no longer seem to be in danger. To a herder, once a threat, always a threat."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "Characters can scavenge one random cypher from a herder’s body."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_186_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_186_Image_0002.png"
+    },
+    {
+      "name": "Hungry Pennon",
+      "source": "AotA",
+      "page": 185,
+      "size": "M",
+      "type": "aberration",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 71,
+        "formula": "13d8 + 13"
+      },
+      "speed": {
+        "walk": 5,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 17,
+      "dex": 15,
+      "con": 12,
+      "int": 8,
+      "wis": 12,
+      "cha": 14,
+      "save": {
+        "int": "+1",
+        "wis": "+3"
+      },
+      "skill": {
+        "perception": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "resist": [
+        "bludgeoning"
+      ],
+      "languages": [
+        "telepathy 30 ft. (empathy, bonded creatures only)"
+      ],
+      "cr": "4",
+      "trait": [
+        {
+          "name": "Encourage Violence",
+          "entries": [
+            "The host of a hungry pennon has advantage on all attacks."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) piercing damage."
+          ]
+        },
+        {
+          "name": "Aggressive Suggestion",
+          "entries": [
+            "As an action or bonus action, the hungry pennon attempts to convince its host to attack a target. This may be a potential opponent or something that is threatening the host, but it can just as easily be an arbitrary choice by the hungry pennon, such as a pack animal or random person in a village. The host can attempt a {@dc 13} Wisdom saving throw to resist this compulsion (if the host and pennon have been bonded for at least a month, this saving throw has disadvantage). Failure means the host attacks the targeted creature for at least one round. Each round after the first attack, the host can use their reaction to make another saving throw to try to overcome the hungry pennon's compulsion and stop attacking the target."
+          ]
+        },
+        {
+          "name": "Psychic Bond",
+          "entries": [
+            "As an action or bonus action, the hungry pennon can telepathically offer to make a psychic bond with a potential host within 10 feet. The host perceives this as mental images of themselves and the hungry pennon being gloriously victorious in combat. The host must willingly accept this offer for the bond to form. Once the bond is formed, the pennon follows the host. A pennon never willingly leaves a bonded host.",
+            "To break this bond, the host must attack it and inflict enough damage to drive it away or convince it to choose a different host. The bonded host must succeed on a {@dc 13} Intelligence saving throw each time it wants to attack the pennon; failure means they cannot attack it that round. The host has disadvantage on this saving throw. After a month of being bonded, the host cannot willingly break the bond or attack the pennon."
+          ]
+        },
+        {
+          "name": "Death Backlash",
+          "entries": [
+            "If a hungry pennon is killed and the host is within 60 feet, the host takes (17) {@damage 5d6} psychic damage."
+          ]
+        },
+        {
+          "name": "Psychic Shriek {@recharge}",
+          "entries": [
+            "The hungry pennon assails a creature against a single target within 60 feet, dealing 17 ({@damage 5d6}) psychic damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "languageTags": [
+        "TP"
+      ],
+      "damageTags": [
+        "P",
+        "Y"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Hungry pennons are strange beings that resemble a fleshy war banner that hangs freely in the air instead of being connected to a pole. It is large enough to engulf a human-sized creature, but its flat body only has the mass of a large child, most of which is in the form of its fleshy wings. The hungry pennon wants to feed, and it prefers to scavenge the bodies of freshly killed prey. However, a pennon is not an effective predator on its own, and can only bite with the tiny mouths hidden under its wings, so it relies on another creature to do its hunting for it.",
+              {
+                "type": "entries",
+                "name": "Symbiotic Bond",
+                "entries": [
+                  "A hungry pennon psychically attaches itself to another creature, the more aggressive and intelligent the better. If a group of bandits, mercenaries, or vicious abhumans advances under a flapping standard of war that doesn’t actually seem to be connected to a pole, but rather hangs free-floating above one of the combatants, it’s probably not a flag but a hungry pennon. Thus, it drives its host (or hosts) into more frequent and more vicious conflicts. The creature to which a hungry pennon makes this attachment may at first value the advantages provided. But over time, the pennon gains mental ascendancy. If the host is killed, the hungry pennon may flap away, or it may proposition a new host in the area."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "These creatures are found in many colors and patterns. Some have skin the color of yours, mine, or a human’s, but I have seen one with the grey skin of an orc, and heard of others with the red of a tiefling or the green of a lizardfolk. Likewise, they may have stripes, spots, or scales. I wonder, can they change willingly to match their host, or are they born one color and stay that way their entire lives?"
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_188_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_188_Image_0002.png"
+    },
+    {
+      "name": "Imusten Crawler",
+      "source": "AotA",
+      "page": 187,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 110,
+        "formula": "15d10 + 28"
+      },
+      "speed": {
+        "walk": 30,
+        "burrow": 10,
+        "climb": 30
+      },
+      "str": 17,
+      "dex": 12,
+      "con": 15,
+      "int": 8,
+      "wis": 12,
+      "cha": 12,
+      "save": {
+        "str": "+6",
+        "int": "+2"
+      },
+      "skill": {
+        "perception": "+4",
+        "stealth": "+4"
+      },
+      "senses": [
+        "darkvision 30 ft."
+      ],
+      "passive": 14,
+      "resist": [
+        "piercing"
+      ],
+      "languages": [
+        "telepathy 30 ft."
+      ],
+      "cr": "6",
+      "trait": [
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The imusten crawler's attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 5 ft., one target. {@h}24 ({@damage 6d6 + 3}) piercing damage. The target must make a {@dc 15} Constitution saving throw against its poison, which targets the creature's lungs, filling them with a numbing gel which deals 14 ({@damage 4d6}) necrotic damage, or half as much damage on a successful save. If the target fails its save, it must continue to save each round or take damage again as their lungs continue to produce more gel. If the target's hit points reach 0, it begins to suffocate. Any successful saving throw in this process means the creature coughs up the accumulated gel and no longer takes damage or makes saving throws against the venom from that bite.",
+            "If the crawler chooses to poison the target's skin instead of their lungs, their skin produces a slightly different gel that numbs and preserves their flesh. If the damage from the venom gel reduces the target's hit points to 0, it becomes {@condition paralyzed} and {@condition unconscious}, but does not die, and remains this way indefinitely. Eventually the creature may starve to death, but the crawler usually eats its preserved prey before that.",
+            "Sometimes a creature whose lungs were {@condition poisoned} by the crawler's gel is infected with a disease that will slowly turn them into an imusten crawler. Only medical intervention (or the use of magic or numenera) can prevent this transformation."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "languageTags": [
+        "TP"
+      ],
+      "damageTags": [
+        "N",
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "An imusten crawler is a horrific worm-like creature with a diamond- shaped head, its interior edges crusted with fangs and eyes. Its subtle venom causes its victims to secrete a numbing gel that not only holds them in place but also drowns them from the inside as their lungs fill with fluid. The creature is equally likely to attack by clinging to an overhanging structure and wind itself downward or erupting from a tunnel or vent in the earth.",
+              {
+                "type": "entries",
+                "name": "Preserver",
+                "entries": [
+                  "An imusten crawler can direct its venom into a creature’s skin, which coats its target in a layer of gel that paralyzes and numbs the creature indefinitely, allowing it to store food until it becomes hungry. An area filled with this gel is a sure sign that a crawler has been using the space as a larder."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Mysterious Goals",
+                "entries": [
+                  "Imusten crawlers are intelligent but secretive. They resist attempts by other creatures to learn more about them and their ultimate origin. They can’t speak, but they possess a low-level telepathic ability to communicate basic concepts."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Seskii Aversion",
+                "entries": [
+                  "An imusten crawler has an inexplicable fear of {@footnote seskii||Seskii, page 233}. When a crawler is in the presence of a seskii, the seskii’s crystals light up, and the crawler breaks off its attack and wriggles away."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The discarded equipment of an Imusten crawler’s eaten prey sometimes contains valuables, including a few cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_189_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_189_Image_0002.png"
+    },
+    {
+      "name": "Jesanthum",
+      "source": "AotA",
+      "page": 188,
+      "size": "M",
+      "type": "plant",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 38,
+        "formula": "7d8 + 7"
+      },
+      "speed": {
+        "walk": 30,
+        "burrow": 10
+      },
+      "str": 15,
+      "dex": 12,
+      "con": 13,
+      "int": 14,
+      "wis": 11,
+      "cha": 13,
+      "skill": {
+        "perception": "+4",
+        "stealth": "+3"
+      },
+      "senses": [
+        "blindsight 10 ft.",
+        "darkvision 60 ft."
+      ],
+      "passive": 14,
+      "vulnerable": [
+        "fire"
+      ],
+      "conditionImmune": [
+        "blinded",
+        "deafened"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Spore Reproduction",
+          "entries": [
+            "A creature that falls victim to a jesanthum's spore burst attack must succeed on an additional {@dc 13} Constitution saving throw once combat concludes, or the spores germinate in the PC's lungs and send a thick stalk up through their mouth and nostrils sometime during the next day or two. This asphyxiates and kills the victim unless desperate measures are taken, eventually creating the perfect source of nutrition for new jesanthum. Treat as a disease that kills the victim in {@dice 1d4} days."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Impaling Tongue",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d10 + 2}) piercing damage and a Large or smaller target is {@condition grappled} (escape {@dc 14}). Until this grapple ends, the target is {@condition restrained}, and the blight can't impale another target. The target automatically takes 7 ({@damage 1d10 + 2}) piercing damage each round."
+          ]
+        },
+        {
+          "name": "Spore Burst {@recharge}",
+          "entries": [
+            "The jesanthum exhales poisonous gas in a 10-foot-radius sphere centered on it. Each living creature in that area must succeed on a {@dc 13} Constitution saving throw or be {@condition paralyzed} with uncontrollable coughing.",
+            "A victim can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+          ]
+        }
+      ],
+      "senseTags": [
+        "B",
+        "D"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "conditionInflict": [
+        "grappled",
+        "paralyzed",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A patch of wildflowers in the distance waves massive blooms of vivid purple in the breeze. The trembling flowers smell of baking bread and honeyed syrup, an odor so potent that many recall their own best memories of eating sweets.",
+              "When a bed of jesanthum flowers bend their brilliant heads to reveal a lapping tongue the color of blood, and the thick stems uproot to expose powerful {@footnote 5-foot-long carnivorous bodies|Jesanthum can be found almost anywhere sunlight reaches, usually in beds of three to five.} of raking claws and stabbing barbs, those sweet recollections are forever shattered. Before the Ancients vaults opened, no one had ever heard of jesanthum, but now they’re a common cautionary tale among travelers.",
+              {
+                "type": "entries",
+                "name": "Bouquet of Flowers",
+                "entries": [
+                  "To appease an angry patron or provide a gift of special significance for someone the characters need a favor from in return, PCs are asked to collect {@footnote a planter of jesanthum|Jesanthum are pretty, nice-smelling plants— until they’re not, at which point they’re hungry predators that attempt to eat PCs who have come too close.}. However, they are not given any details beyond a bare description of the flower’s “pretty” blooms."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_190_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_190_Image_0002.png"
+    },
+    {
+      "name": "Jiraskar",
+      "source": "AotA",
+      "page": 189,
+      "size": "H",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 168,
+        "formula": "16d12 + 64"
+      },
+      "speed": {
+        "walk": 50
+      },
+      "str": 22,
+      "dex": 16,
+      "con": 19,
+      "int": 7,
+      "wis": 14,
+      "cha": 12,
+      "skill": {
+        "perception": "+6",
+        "stealth": "+7"
+      },
+      "senses": [
+        "blindsight 90 ft."
+      ],
+      "passive": 16,
+      "immune": [
+        "psychic"
+      ],
+      "cr": "11",
+      "trait": [
+        {
+          "name": "Illusion Liberty",
+          "entries": [
+            "The jiraskar has advantage on saving throws to resist being {@condition charmed} or {@condition paralyzed}. In addition, it has advantage on saves against illusions, poison, and spells."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The jiraskar makes two bite attacks."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}22 ({@damage 3d10 + 6}) piercing damage."
+          ]
+        },
+        {
+          "name": "Tail Slap {@recharge 5}",
+          "entries": [
+            "The jiraskar's tail sweeps out in a 20 foot cone with savagery. Each creature in that area must make a {@dc 16} Dexterity saving throw, taking 66 ({@damage 12d10}) bludgeoning damage on a failed save, or half as much if successful."
+          ]
+        },
+        {
+          "name": "Swallow",
+          "entries": [
+            "As a bonus action, the jiraskar swallows a creature that it has bitten twice this round. While swallowed, the target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the jiraskar, and it takes 21 ({@damage 6d6}) acid damage at the start of each of the jiraskar's turns. A jiraskar can have only one creature swallowed at a time.",
+            "If the jiraskar takes 30 damage or more on a single turn from the swallowed creature, the jiraskar must succeed on a {@dc 14} Constitution saving throw at the end of that turn or regurgitate the creature, which falls {@condition prone} in a space within 10 feet. If the jiarskar dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 15 feet of movement, exiting {@condition prone}."
+          ]
+        }
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack",
+        "Swallow"
+      ],
+      "damageTags": [
+        "A",
+        "B",
+        "P"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "conditionInflict": [
+        "blinded",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Terror doesn’t even begin to describe it. The woods seem still. Quiet. At the risk of sounding cliché́, too quiet. Then there is a tremor. A rumbling. Far more quickly than you might expect (if you were smart enough to realize that the rumbling was the approach of a large beast), a terrible but beautiful shape emerges from the tall trees, a creature as colorful as a jungle flower but burgeoning with teeth and hunger and death. Your doom charges at you as though destiny guided its feet. The only mercy is that it ends as quickly as it began.",
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "I apologize. I have a natural inclination to find refuge among the trees, and I felt the jiraskar would have trouble pursuing us there. I had no way of knowing that one sweep of its tail would break through every mighty trunk and give it a clear opportunity to swallow you whole."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Apology accepted, if you help me find my healing potions in its guts, these acid burns really sting."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Apex predators",
+                "entries": [
+                  "Jiraskars’ {@footnote colorful bodies|Jiraskars might have started as normal lizards or birds that were quickly evolved and released by some inscrutable device of the Ancients.} have fleshy frills and only two functioning limbs: powerful legs that carry them at prey with great speed. They have poor (practically nonexistent) natural senses, but they have a mysterious capacity to perfectly sense their environment, instantly seeing through illusion, invisibility, and similar distractions as if their perceptions were based on something entirely different than—and superior to—other creatures. The huge beasts live only to hunt. And because most of their prey is small, they must kill continually to survive."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Despite its size, a jiraskar’s coloration and natural stealthiness mean it often can approach within 100 feet of potential prey before it is noticed (usually the tremors of its footfalls and the crashing of knocked-over terrain obstacles are what gives it away). By then it is often too late, as it can reach its target with a move or a quick dash if necessary."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Fierce Animals of the Wild",
+                "entries": [
+                  "Jiraskars are extremely fast. They are animals and act as such. They charge in with a savage bite and don’t stop biting until the prey is dead or they are. Because jiraskars are so fast, an encounter with one can arise very quickly. And because they are so powerful, an encounter can also end very quickly."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_192_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_192_Image_0002.png"
+    },
+    {
+      "name": "Jurulisk",
+      "source": "AotA",
+      "page": 191,
+      "size": "L",
+      "type": "aberration",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 165,
+        "formula": "17d10 + 72"
+      },
+      "speed": {
+        "walk": 60
+      },
+      "str": 19,
+      "dex": 17,
+      "con": 18,
+      "int": 14,
+      "wis": 14,
+      "cha": 18,
+      "save": {
+        "dex": "+7",
+        "con": "+8",
+        "wis": "+6",
+        "cha": "+8"
+      },
+      "senses": [
+        "truesight 120 ft."
+      ],
+      "passive": 12,
+      "resist": [
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks not made with silvered weapons"
+        }
+      ],
+      "immune": [
+        "cold",
+        "poison"
+      ],
+      "conditionImmune": [
+        "poisoned",
+        "charmed"
+      ],
+      "cr": "12",
+      "trait": [
+        {
+          "name": "Incorporeal Movement",
+          "entries": [
+            "The jurulisk can move through other creatures and objects as if they were difficult terrain. It takes 5 ({@damage 1d10}) force damage if it ends its turn inside an object."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The jurulisk has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magical Weapons",
+          "entries": [
+            "The jurulisk's weapon attacks (piercing chill touch) are treated as if magical."
+          ]
+        },
+        {
+          "name": "Regeneration",
+          "entries": [
+            "The jurulisk regains 10 hit points at the start of its turn. If the jurulisk starts its turn with 0 hit points, it collapses into so many separate one-dimensional lines and regains 1 hit point per hour, until it reforms after a full day. While it is regenerating in this way, it can't take any other actions. (If the jurulisk falls to 0 hit points because its component matter is scattered across a distance of 120 feet or farther, perhaps due to an explosion, it does not regenerate.)"
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The jurulisk makes three piercing chill touch attacks."
+          ]
+        },
+        {
+          "name": "Piercing Chill Touch",
+          "entries": [
+            "{@atk mw} {@hit 8} to hit, reach 25 ft. (it can stretch so as to extend a \"limb\" to stab at a foe up to 25 feet away), one target. {@h}9 ({@damage 1d10 + 4}) piercing damage, plus 13 ({@damage 3d8}) cold damage."
+          ]
+        },
+        {
+          "name": "Object Draining Touch",
+          "entries": [
+            "Instead of a multiattack, a jurulisk makes a single piercing chill touch attack. If it hits, the Jurulisk targets an object carried by a creature; either a weapon, armor, or preferably, a device of the numenera. The touched object is drained and gains a permanent and cumulative -1 penalty, either to AC, to hit, or if a device that provides some other benefit, to associated checks. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed, as is a weapon reduced to-5."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Incorporeal Movement",
+        "Magic Resistance",
+        "Regeneration"
+      ],
+      "senseTags": [
+        "U"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "C",
+        "O",
+        "P"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "The Ancients, with their strange activities and vast displays of power, tore literal holes in the fabric of the universe. Sometimes, these were very small. Nothing to worry about.",
+              "The jurulisk hails from inconceivable dimensions. When it comes to this world, it is a one-dimensional line, possessing only length (not even width, let alone depth), imperceptible and incapable of interacting in a meaningful way. Eventually, others come to this world. Over the aeons, the jurulisks find each other and bond to form two- and eventually three-dimensional forms in a way that is difficult to comprehend.",
+              "Finally able to interact with the three- dimensional world, the jurulisk seeks energy to fuel its new form. Once it absorbs a great deal of power from living creatures, the sun, or an artificial energy source, a jurulisk attempts to control its environment—usually by eliminating {@footnote other potential threats|If it is possible to communicate or interact with a jurulisk, the means have not been discovered yet, even using telepathy.}, which means all other creatures.",
+              {
+                "type": "entries",
+                "name": "Alive? Yes, But.",
+                "entries": [
+                  "The jurulisk is a living creature, but it is not organic in any traditional sense, and neither is it mechanical. Its form constantly shifts, adapting to its needs at the moment, but always looking like what some have described as “the framework for an ‘actual’ creature.” A jurulisk fights to the “death,” although it might not be permanently dead or destroyed, for such concepts might not apply. The creature is far too alien to tell."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_193_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_193_Image_0002.png"
+    },
+    {
+      "name": "Kanthid",
+      "source": "AotA",
+      "page": 192,
+      "size": "M",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 66,
+        "formula": "12d8 + 12"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 16,
+      "dex": 14,
+      "con": 13,
+      "int": 5,
+      "wis": 12,
+      "cha": 16,
+      "skill": {
+        "deception": "+5",
+        "stealth": "+4"
+      },
+      "senses": [
+        "blindsight 60 ft."
+      ],
+      "passive": 11,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "poisoned"
+      ],
+      "languages": [
+        "none",
+        "(no smarter than clever animals, even the ones that colonized the bones of an intelligent creature)"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The kanthid has advantage on saving throws against spells and other magical effects."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The kanthid bites twice."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one creature. {@h}5 ({@damage 1d4 + 3}) piercing damage plus 3 ({@damage 1d6}) poison damage.",
+            "If one target takes poison damage from the kanthid three times, it must succeed on a {@dc 14} Constitution saving throw. If the saving throw fails by 5 or more, the creature is instantly {@condition paralyzed}. Otherwise, a creature that fails the save begins to become {@condition paralyzed} and is {@condition restrained}. The {@condition restrained} creature must repeat the saving throw at the end of its next turn, becoming {@condition paralyzed} on a failure or ending the effect on a success. The paralysis lasts for 10 minutes, or less if the kanthid takes its Colonize action."
+          ]
+        },
+        {
+          "name": "Colonize",
+          "entries": [
+            "If allowed to do so without interruption, a kanthid lowers its body across a {@condition paralyzed} (or recently slain) creature, allowing its many ciliated mouths to feed. Each round a kanthid feeds in this fashion automatically deals Bite damage.",
+            "A kanthid that completely consumes a meal leaves behind a skeleton chunked with gore and several hard nodules of kanthid eggs fused to the bone."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Magic Resistance"
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "I",
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "paralyzed",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "The sound of sandpaper on sandpaper scratches the air when a kanthid moves. Most kanthids are multilimbed creatures shaped vaguely like other beasts and creatures. {@footone Whatever its underlying shape|Breaking open a defeated kanthid reveals it to be a composite creature made of hundreds of smaller “polyps” (essentially, tentacles surrounding a mouth and digestive sac protected by a mineral encrustation) built on the skeleton of a dead animal}, the rough skin of a kanthid is a stony mineral whorled and studded with short spines. Here and there, openings in the stone reveal mouths ringed in writhing cilia.",
+              {
+                "type": "entries",
+                "name": "Speech Mimickers",
+                "entries": [
+                  "Kanthids with biped, humanoid shapes sometimes speak, though they don’t make much sense. Streams of nonsense, rhymes, names, stories, and even snippets of song might emerge from two or three different cilia-ringed mouths at once. Though a talking kanthid seems to make little sense, there is a theme to its babble: everything a given kanthid says or sings were things once said or sung by a particular individual, one who’s been dead for a while."
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "It knows what Jarin knew. Jarin’s been gone for years; I know he’s dead. But then the thing appeared at my window, whispering words of love and our old happiness. It’s not Jarin, I understand that. But I’m going down to meet it anyhow, out behind the wall where Jarin and I used to meet."
+                    ],
+                    "by": "Note left by Salara before she went missing"
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Walking Dead, Almost",
+                "entries": [
+                  "A wizard wanted information that only a dead and buried colleague had. Knowing of the kanthid ability to evoke the memories of slain victims, she infected the graveyard where her colleague was interred. A few miscalculations and weeks later, the entire graveyard and associated village was infected with wandering kanthids. Now that wizard seeks help in locating the particular kanthid she wants to interrogate among those radiating out from the village, though she’s careful to keep secret her part in creating the infection in the first place."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_194_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_194_Image_0002.png"
+    },
+    {
+      "name": "Killist",
+      "source": "AotA",
+      "page": 193,
+      "size": "S",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "killist"
+        ]
+      },
+      "alignment": [
+        "C",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 12,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 21,
+        "formula": "5d6 + 4"
+      },
+      "speed": {
+        "walk": 30,
+        "swim": 40
+      },
+      "str": 13,
+      "dex": 11,
+      "con": 12,
+      "int": 8,
+      "wis": 13,
+      "cha": 9,
+      "skill": {
+        "stealth": "+4"
+      },
+      "senses": [
+        "darkvision 120 ft."
+      ],
+      "passive": 15,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "poison"
+      ],
+      "languages": [
+        "Killist",
+        "about half have learned a few words of Common"
+      ],
+      "cr": "1/2",
+      "trait": [
+        {
+          "name": "Strength in Numbers",
+          "entries": [
+            "A killist gains advantage on attacks if it and its target are within 5 feet of another killist that isn't {@condition incapacitated}."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) piercing damage plus 3 ({@damage 1d6}) poison damage."
+          ]
+        },
+        {
+          "name": "Claws",
+          "entries": [
+            "{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) slashing damage plus 3 ({@damage 1d6}) poison damage."
+          ]
+        },
+        {
+          "name": "Shortbow",
+          "entries": [
+            "{@atk rw} {@hit 3} to hit, range 20/60 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage plus 3 ({@damage 1d6}) poison damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "SD"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "I",
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RNG",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Clawed, greasy fingers. Smacking lips. Chattering, pointed teeth. Tiny, beady eyes. Shrill voice. A penchant for thievery, murder, traps, and deception. It is difficult to find some aspect of a killist that isn’t annoying, off-putting, or downright abhorrent. There is a saying: “If a killist is speaking, you are listening to lies.” Killisti can be intimidated by shows of obvious force and threats to their lives, but even as they are cowed, they are plotting a way to trick and betray you.",
+              "{@footnote Killisti are diminutive corrupt humanoids|Killisti leaders are typically older females who may be the mother or grandmother of their entire band (typically a challenge 3 creature in their own right). They are even more devious and cruel than the others and thus retain their positions of authority. In addition to the matriarch, kiillisti can be found in bands of six to twelve.}, possibly forcibly mutated by devices found in an Ancients’ cache. Their oily flesh is pale, their eyes are dark, and they have slits on the sides of their torso that are frequently mistaken for gills. These, in fact, provide access to their poison sacs, which are positioned perfectly for killisti to slide their claws into as a part of an attack.",
+              {
+                "type": "entries",
+                "name": "Malice against Humans",
+                "entries": [
+                  "Killisti hate humanity with a passion and delight in murder and sadistic acts against the targets of their malice. (They regard other similarly proportioned species as foes, but not with the murderous rage with which they react to humans; possibly because their ancestors were once human.)"
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Ambushers and Poisoners",
+                "entries": [
+                  "Killisti hate and fear a fair fight. They set ambushes and traps whenever possible. Traps usually consist of spiked pits, tripwires, or spine-filled nets. Any sharp points in their traps are poisoned. Most killisti carry long knives and crude bows. These weapons are always freshly envenomed from the poison-seeping slits in their sides.",
+                  "A band of killisti might set up an ambush at a bridge or along a road. They might even “bait” that trap with one of their number pretending to be hurt or dead at the center of the ambush. Other killisti may live on the edges of civilized areas, stealing what they need and preying upon those weaker than themselves. For example, a town with an infestation of killisti might start to experience disappearances among children or the elderly."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_195_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_195_Image_0002.png"
+    },
+    {
+      "name": "Laak",
+      "source": "AotA",
+      "page": 194,
+      "size": "T",
+      "type": "beast",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        12
+      ],
+      "hp": {
+        "average": 7,
+        "formula": "2d6"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 7,
+      "dex": 15,
+      "con": 11,
+      "int": 2,
+      "wis": 10,
+      "cha": 4,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 10,
+      "immune": [
+        "poison"
+      ],
+      "cr": "1/8",
+      "trait": [
+        {
+          "name": "Pack Tactics",
+          "entries": [
+            "Laaks have advantage on attacks against a creature if at least one other active laak is within 5 feet of the creature."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Poison Bite",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d4 + 2}) piercing damage, and the target must succeed on a {@dc 12} Constitution saving throw or take 5 ({@damage 1d10}) poison damage."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Pack Tactics"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "I",
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "If you see one laak, you know that at least ten more are hiding nearby, probably measuring their chances on taking you down if you’re out alone."
+                    ]
+                  }
+                ]
+              },
+              "Laaks are small, green-skinned, poisonous reptiles that attack larger prey in small groups. They can leap with surprising speed and strength. Found almost everywhere Ancients’ caches are dug up, laaks can become a scourge as they spread farther. However, they avoid cold regions.",
+              {
+                "type": "entries",
+                "name": "Vicious Pets",
+                "entries": [
+                  "A few industrious souls have captured young laaks and trained them as vicious pets and guardians. They can be frightened off by displays of power (such as fire, noise, and the like). Although laaks are ubiquitous and annoying, they are generally not a huge threat to PCs. However, an encounter with a powerful NPC foe who keeps a few laaks as pets could be more interesting and more dangerous."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Sensitive to Odor",
+                "entries": [
+                  "Certain scents seem to draw laak attacks. For example, the scent of most dyes (textile, written words, even hair) seems to enrage them, while the smell of smoke can drive them away."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_196_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_196_Image_0002.png"
+    },
+    {
+      "name": "Latos",
+      "source": "AotA",
+      "page": 196,
+      "size": "G",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 22,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 498,
+        "formula": "26d20 + 225"
+      },
+      "speed": {
+        "walk": 60
+      },
+      "str": 30,
+      "dex": 10,
+      "con": 29,
+      "int": 18,
+      "wis": 15,
+      "cha": 23,
+      "save": {
+        "dex": "+7",
+        "con": "+16",
+        "wis": "+9"
+      },
+      "skill": {
+        "arcana": "+11",
+        "perception": "+16"
+      },
+      "senses": [
+        "blindsight 120 ft."
+      ],
+      "passive": 26,
+      "immune": [
+        "fire",
+        "poison",
+        "psychic",
+        {
+          "immune": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks that aren't adamantine"
+        }
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "cr": "23",
+      "trait": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "entries": [
+            "If the latos fails a saving throw, it can choose to succeed instead."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The latos has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magic Weapons",
+          "entries": [
+            "The latos weapon attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The latos can use one of the three facets of its Mental Assault (if they are recharged). It then makes two attacks with its colossal fists."
+          ]
+        },
+        {
+          "name": "Fist",
+          "entries": [
+            "{@atk mw} {@hit 17} to hit, reach 15 ft., one target. {@h}21 ({@damage 2d10 + 10}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Mental Assault",
+          "entries": [
+            "Whenever the latos uses Mental Assault, it chooses from one of the three following \"facets.\"",
+            {
+              "type": "list",
+              "style": "list-hang-notitle",
+              "items": [
+                {
+                  "type": "item",
+                  "name": "Wide Assault {@recharge 5}.",
+                  "entries": [
+                    "All creatures within a 1-mile- radius sphere centered on the latos must succeed on a {@dc 21} Wisdom saving throw or take 22 ({@damage 4d10}) psychic damage on a failed save, or half as much damage on a successful one."
+                  ]
+                },
+                {
+                  "type": "item",
+                  "name": "Massive Assault {@recharge 5}.",
+                  "entries": [
+                    "All creatures within a 60-foot- radius sphere centered on the latos must succeed on a {@dc 21} Wisdom saving throw or take 88 ({@damage 16d10}) psychic damage on a failed save, or half as much damage on a successful one."
+                  ]
+                },
+                {
+                  "type": "item",
+                  "name": "Dream Assault {@recharge}.",
+                  "entries": [
+                    "All creatures within a 1-mile- radius sphere centered on the latos must succeed on a {@dc 21} Wisdom saving throw or have their consciousnesses transferred to a limited artificial dimension where they wander in a dreamlike world. A single round in the real world seems like a full day to the victims.",
+                    "A victim can be rescued only by an external source, such as a telepathic ally who journeys into their mind to find and retrieve them (perhaps combatting the dream-like phantoms that confront them).",
+                    "A character who spends more than an apparent year in this dream state suffers the permanent loss of 1 point from their Intelligence score for each year. In addition, each apparent year, they must succeed on a {@dc 21} Wisdom save or lose their wits."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "legendary": [
+        {
+          "name": "Fist Attack",
+          "entries": [
+            "The latos makes one fist attack."
+          ]
+        },
+        {
+          "name": "Teleport (Costs 2 Actions)",
+          "entries": [
+            "The latos teleports up to 500 feet to an unoccupied space it can see."
+          ]
+        },
+        {
+          "name": "Recharge (Costs 3 Actions)",
+          "entries": [
+            "The latos automatically recharges one of the facets of its mental assault ability."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Legendary Resistances",
+        "Magic Resistance",
+        "Magic Weapons"
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "Y"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "The civilizations that created the numenera have been gone for ages before my kind were part of this world. Even these caches and other remnants are just what they discarded and things that somehow survived great spans of time without failing. But the latos preserves within it an intact piece set aside by its creatures. To see such a thing, to walk among its creatures and constructions, would be like walking in the garden of the gods as they were creating worlds."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              "Gigantic and mysterious, latoses are very rare, found only in the remotest areas. For some reason, the Ancients decided to preserve locations within small, artificially closed universes and hide them away inside massive guardians. The ways of the Ancients were strange indeed.",
+              "The 50-foot body of a latos is made of a unique alloy, and its head is a transparent sphere that contains an area far larger than its size would indicate. In this area, reflected in the “face” of the latos, is {@footnote a place of Anceint importance, permanently preserved and deserted|If the latos is destroyed, its body shatters and scatters across a mile radius. At the center of that area, the location stored in the sphere is transplanted as if it had always been there. It is perfectly preserved but empty of life (except perhaps for machine entities or creatures that were in stasis).}.",
+              {
+                "type": "entries",
+                "name": "Accessing What a Latos Guards.",
+                "entries": [
+                  "No one has ever successfully spoken with a latos, but a character with telepathic abilities (or a device) might be able to establish a dialogue with one of these enigmatic creatures. If so, the PCs have a decent chance at negotiating a peaceful agreement, as latoses are not inherently aggressive, but they would have to work extremely hard to convince the latos to provide access to the location it protects. But should they manage such a feat, a latos can transport a willing target into the location stored in its sphere by touch."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "The closed universe within a latos may be a place that explorers can reach through other means, such as dimensional travel. Navigating to such a location would be perilous and protected by other guardians and devices of the numenera. If explorers were able to reach it, the latos guarding that space would almost immediately become aware of the intrusion and either attack or attempt to eject the intruders."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "Aside from the transplanted location itself, scavengers picking through the artificial body of a destroyed latos will find {@dice 1d10 + 6} cyphers, {@dice 1d6} oddities, and one or two relics."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_197_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_197_Image_0002.png"
+    },
+    {
+      "name": "Margr",
+      "source": "AotA",
+      "page": 197,
+      "size": "M",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "margr"
+        ]
+      },
+      "alignment": [
+        "C",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 17,
+          "from": [
+            "{@item chain shirt|phb}",
+            "{@item shield|PHB}"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 22,
+        "formula": "5d8"
+      },
+      "speed": {
+        "walk": {
+          "number": 30,
+          "condition": "actions"
+        }
+      },
+      "str": 11,
+      "dex": 14,
+      "con": 10,
+      "int": 10,
+      "wis": 8,
+      "cha": 8,
+      "skill": {
+        "athletics": "+4"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 9,
+      "languages": [
+        "Common",
+        "Margr"
+      ],
+      "cr": "1",
+      "trait": [
+        {
+          "name": "Margr Cunning",
+          "entries": [
+            "The margr has advantage on Intelligence, Wisdom, and Charisma saving throws against trickery, lies, and illusion, including magic that attempts to do the same."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The margr makes two attacks with its spear. The second attack has disadvantage."
+          ]
+        },
+        {
+          "name": "Spear",
+          "entries": [
+            "{@atk mw,rw} {@hit 4} to hit, reach 5 ft. or range 30/120 ft., one target. {@h}5 ({@damage 1d6 + 2}) piercing damage."
+          ]
+        }
+      ],
+      "reaction": [
+        {
+          "name": "Parry",
+          "entries": [
+            "The margr adds 2 to its AC against one melee attack that would hit it. To do so, the margr must see the attacker and be wielding a melee weapon."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack",
+        "Parry"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW",
+        "RW",
+        "THW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "No two margr look alike, but most are around human-size and have some aspect of goat—a goat head, goat horns, goat legs, goat hooves, {@footnote or some combination or varying degrees thereof|Margr are likely some hybrid between human and animal, crafted by an unthinking numenera device in an accidental surge of flesh-fusing power.}. Margr live lives of terrible violence, killing each other (or really, anything they find) out of rage, sport, or lust. They breed and mature quickly, however, so their numbers never seem to diminish. {@footnote They travel in small bands led by the strongest and most savage|Margr chieftains can reach terrifying size. Some report the rare individual at 8 or 9 feet in height.}.",
+              {
+                "type": "entries",
+                "name": "Attired for Arocity",
+                "entries": [
+                  "Margr wear trophies of their dead opponents but are poor crafters, so these displays are crude at best—severed heads on hooks, ears or fingers threaded on cords as necklaces, and so forth. This means that, on top of everything else, margr stink of rotting meat at all times."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Influenced from the Top",
+                "entries": [
+                  "Margr are vicious and bloodthirsty. They are not smart, but they are crafty, making them difficult to fool. Killing their leader sends them into a frenzy of confusion and fear. In this situation, PCs could easily escape, but they could also intimidate the remaining margr into doing as they command. A very powerful and forceful character could become the new leader, but such a position would be challenged so frequently that it would make the margr poor followers overall."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Born Raiders",
+                "entries": [
+                  "Margr harass civilized people on a regular basis, raiding villages or trade caravans. Some communities put bounties on their heads, hoping that mercenaries will eliminate the threat, but people not aware of margr origins often think of margr as creatures of supernatural evil—demons or devils—and do their best to hide from them. Thankfully, the nomadic margr usually move on after a few raids."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_199_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_199_Image_0002.png"
+    },
+    {
+      "name": "Mastigophore",
+      "source": "AotA",
+      "page": 198,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 61,
+        "formula": "9d8 + 21"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 20,
+      "dex": 12,
+      "con": 17,
+      "int": 14,
+      "wis": 12,
+      "cha": 7,
+      "skill": {
+        "perception": "+3"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 13,
+      "languages": [
+        "Mastigophore"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Keen Sight and Smell",
+          "entries": [
+            "The mastigophore has advantage on Wisdom (Perception) checks that rely on sight or smell."
+          ]
+        },
+        {
+          "name": "Self Destruction",
+          "entries": [
+            "When a mastigophore dies, it explodes on a 1-2 on 1d6. All creatures within 5 feet of it must succeed on a {@dc 14} Dexterity save or take {@damage 4d8} fire damage, or half that if successful."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The mastigophore makes two attacks: one with each of the barbed whips it extrudes from both hands."
+          ]
+        },
+        {
+          "name": "Whip",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 15 ft., one creature. {@h}10 ({@damage 1d10 + 5}) piercing damage, and the target must succeed on a {@dc 14} Constitution saving throw or be {@condition stunned} during their next turn."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Keen Senses"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Mastigophores are automatons that look human but {@footnote can instantly transform their hands into long, barbed whips whenever they wish|With a thought, mastigophores can extrude organic matter from their wrists in the form of long, barbed whips.}. When first encountered, {@footnote appear to be average, uniformed humans with a military stance|Mastigophores can take on the appearance of other humanoids, such as elves, or orcs, if they gain enough experience with such creatures.}. Quiet and excellent stalkers, they are encountered in one of two modes: on guard or hunting.",
+              "Mastigophores guard certain ancient ruins, complexes, or machines, usually in groups of two or more. They warn trespassers away once with unintelligible words (but obvious intentions), and if their warning is not heeded, they attack and fight without regard for their safety.",
+              {
+                "type": "entries",
+                "name": "Hungry Constructs.",
+                "entries": [
+                  "Despite their machine-filled interiors, mastigophores need to consume organic material to function and create their weapons. Although they can subsist on plant matter, whoever created mastigophores designed them to enjoy hunting and killing animal prey. In this endeavor, they are very aggressive, and they act alone, leaving their “partners” behind to guard whatever it is they’re protecting."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Lost Language",
+                "entries": [
+                  "Mastigophores speak, but not in any language known today. Stern and focused, they cannot be convinced to shirk their duties. However, if they are not hunting, and if the PCs don’t try to get past them while they are standing guard, mastigophores are not hostile."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_200_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_200_Image_0002.png"
+    },
+    {
+      "name": "Merkadian Soldier",
+      "source": "AotA",
+      "page": 198,
+      "size": "M",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "merkadian soldier"
+        ]
+      },
+      "alignment": [
+        "L",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 18,
+        "formula": "4d8"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 10,
+      "dex": 14,
+      "con": 10,
+      "int": 11,
+      "wis": 11,
+      "cha": 12,
+      "skill": {
+        "perception": "+2",
+        "stealth": "+4"
+      },
+      "senses": [
+        "darkvision 120 ft."
+      ],
+      "passive": 12,
+      "languages": [
+        "Merkadian",
+        "any languages known by its host body"
+      ],
+      "cr": "1/4",
+      "trait": [
+        {
+          "name": "Stealth Field {@recharge}",
+          "entries": [
+            "The soldier uses its action to become blurred, indistinct, and odorless for one minute. For the duration, the soldier gains advantage on stealth checks and creatures have disadvantage on attacks against the soldier, including against creatures with blindsight."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Longsword",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) piercing damage."
+          ]
+        },
+        {
+          "name": "Detonation Lobber {@recharge 5}",
+          "entries": [
+            "Ranged Weapon Attack:",
+            "{@hit 4} to hit, range 30/120 ft., one target. {@h}5 ({@damage 1d6 + 2}) fire damage, and all targets within 10 feet must succeed on a {@dc 13} Dexterity saving throw or take the same damage."
+          ]
+        }
+      ],
+      "reaction": [
+        {
+          "name": "Death Regeneration",
+          "entries": [
+            "If the soldier starts its turn with 0 hit points, it seems dead. However, it regains 1 hit point per hour, until it reforms after a full day unless its blade, which was fused with its hand, is separated by more than 30 feet. While it is regenerating in this way, it can't take any other actions."
+          ]
+        }
+      ],
+      "senseTags": [
+        "SD"
+      ],
+      "damageTags": [
+        "F",
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "The stink of rotting flesh often precedes the appearance of a so-called Merkadian soldier. The soldier is never far behind its odor, moving with amazing alacrity for a humanoid that is otherwise apparently dead. Clutched in one hand is a sword crusted with all manner of the numenera. These vicious soldiers understand only destruction and war. They may respond to queries in the language of their host body, describing how they are soldiers of Grand Merkadia (a place that doesn’t exist, or at least one that hasn’t existed since the time of the Ancients). Particularly crafty negotiators might be able to form a short-lived alliance with a soldier.",
+              {
+                "type": "entries",
+                "name": "Alone or Part of a Platoon",
+                "entries": [
+                  "Lone Merkadian soldiers can be found anywhere, usually looking for enemies to destroy or other platoon members. In rare instances, platoons of up to twenty-six Merkadian soldiers manage to assemble, at which time their tactics change from sneaking assassination to full frontal assault."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Almost Nerver-dying",
+                "entries": [
+                  "A defeated Merkadian soldier often returns to life, though afterward it looks more corpselike than ever, and its eyes more hollowed-out. Clutched in one hand is a sword encrusted with all manner of the numenera, which could be the source of the soldier’s ability to return to the fight even after receiving mortal wounds."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "\"Cursed\" Blade",
+                "entries": [
+                  "If a Merkadian soldier’s sword is taken as loot (treat it as a longsword), tiny machines, too small to be easily noticed, begin to move from it into the PC who claims the blade. The effect initially disfigures the character, causing raised metallic veins to appear all over their flesh. The contaminated item is obviously responsible for the infection, and if it is destroyed or abandoned, the infection subsides. The longer the PC keeps the contaminated item, the more their dreams Ware filled with imagery of a long-concluded war fought above the atmosphere, and the greater the chance that they don’t wake at all, except as {@footnote a reprogrammed Merkadian soldier pledged to fight in a dead conflict with no memory of any previous existence|There is little hope for a character fully changed into a Merkadian soldier, though anything is possible if the right machine of the Ancients is found.}."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "The transformation ability of a Merkadian soldier is perhaps the closest thing we have seen to necromancy in the numenera. I am not sure if this creature is best characterized as a lich, mummy, or some kind of revenant. Of course, as with most things in the numenera, our magical explanations are more for our contemporary convenience than accurate descriptions of a creature’s nature."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_200_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_200_Image_0002.png"
+    },
+    {
+      "name": "Mesomeme",
+      "source": "AotA",
+      "page": 201,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 144,
+        "formula": "17d10 + 51"
+      },
+      "speed": {
+        "walk": 30,
+        "swim": 30
+      },
+      "str": 18,
+      "dex": 15,
+      "con": 16,
+      "int": 6,
+      "wis": 13,
+      "cha": 15,
+      "skill": {
+        "deception": "+5",
+        "perception": "+4",
+        "stealth+5(whilemoving": "underwater)"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 14,
+      "cr": "6",
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The mesomeme makes two attacks: one with each of its two pincers once it rises from the water. If the mesomeme hits the same creature with both pincers as part of one Multiattack, the mesomeme can also use its sever head attack."
+          ]
+        },
+        {
+          "name": "Pincers",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}7 ({@damage 1d6 + 4}) piercing damage."
+          ]
+        },
+        {
+          "name": "Sever Head",
+          "entries": [
+            "The target must succeed on a {@dc 14} Constitution saving throw or drop to 0 hit points. At the beginning of its next turn, the target must succeed on a modified death saving throw. If successful, it regains 1 hit point and is {@condition restrained}.",
+            "If it fails, its head is severed by a pincer. The severed head is placed on a new tendril that rises up to impale it, which occurs as a separate reaction on the mesomeme's part.",
+            "Attacking a mesomeme's severed heads accomplishes nothing more than robbing the crustacean of long-term sustenance."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "When first encountered, a mesomeme often appears to be a number of individual creatures—people and animals—perhaps swimming or wading in shallow water. Each person is speaking, and the animals are making noises as well. It’s a strange choir of babble. Only on closer inspection does it become clear that the creatures are just severed heads mounted on slender, grey tendrils that are almost translucent. These tendrils sprout from holes in the chitinous shell of a massive crustacean with eight legs, two of which end in massive pincers.",
+              {
+                "type": "entries",
+                "name": "Façade of Intelligence",
+                "entries": [
+                  "Façade of Intelligence. Despite the fact that the severed heads on the tendrils speak, the mesomeme cannot do so, nor can it understand speech. It is not very intelligent and acts on instinct. The mesomeme feeds on the mental activity of its victims, stimulating the brains in their severed heads, which remain preserved for weeks on its tendrils. {@footnote This stimulation causes the heads to speak or otherwise babble, growl, or squawk.|Sometimes a severed head says something so startling (perhaps coincidentally meaningful or relevant to one of the characters) that a PC is fooled into thinking that the mesomeme is sapient.}",
+                  "At any given time, the mesomeme has 1d6 + 4 heads. If it dwells near civilization, half of the heads will be human, elves, dwarves, and so on, and the other half will be other types of creatures, such as orcs, goblins, large mammals or reptiles, or large birds."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Babblign Thing",
+                "entries": [
+                  "A potential encounter with a mesomeme involves a small town being terrorized by a creature the locals call “the babbling thing” that lives in a nearby lake. However, some people instead claim that the lake is haunted by the recently dead, whose voices can still be heard echoing across the water. Either way, the residents would be eternally grateful to anyone who can rid them of the menace that makes it too dangerous to fish or get fresh water."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_203_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_203_Image_0002.png"
+    },
+    {
+      "name": "Mlox",
+      "source": "AotA",
+      "page": 203,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N",
+        "G"
+      ],
+      "ac": [
+        12
+      ],
+      "hp": {
+        "average": 66,
+        "formula": "12d8 + 12"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 16,
+      "dex": 14,
+      "con": 13,
+      "int": 14,
+      "wis": 12,
+      "cha": 16,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 11,
+      "resist": [
+        {
+          "resist": [
+            "piercing  slashing"
+          ],
+          "note": "from nonmagical attacks"
+        }
+      ],
+      "immune": [
+        "poison",
+        "psychic"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "Mlox",
+        "Common"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Open Third Eye (Recharge After Short Rest)",
+          "entries": [
+            "The mlox uses their action to open their third eye. For 1 minute, the mlox can see in normal (and magical) darkness, see {@condition invisible} creatures and objects, automatically detect visual illusions and succeed on saving throws against them, and perceive the original form of a shapechanger or a creature that is otherwise transformed.",
+            "The mlox may also peer into neighboring planes of existence that impinge on their current reality.",
+            "In addition, the mlox can use open eye actions."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The mlox makes two shortsword attacks."
+          ]
+        },
+        {
+          "name": "Shortsword",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) slashing damage."
+          ]
+        },
+        {
+          "name": "Open Eye Actions",
+          "entries": [
+            "The mlox can take 1 open eye action, choosing from the options below. Only one open eye action option can be used at a time and only at the end of another creature's turn (though Eyeflash can be used during another creature's turn).",
+            "The mlox regains spent open eye actions at the start of its turn, while their third eye is open.",
+            {
+              "type": "list",
+              "style": "list-hang-notitle",
+              "items": [
+                {
+                  "type": "item",
+                  "name": "Shortsword",
+                  "entries": [
+                    "The mlox makes a shortsword attack."
+                  ]
+                },
+                {
+                  "type": "item",
+                  "name": "Eyebeam",
+                  "entries": [
+                    "The mlox fires a single beam of energy (from its third eye) at a foe within 120 feet that it can sense, dealing 7 ({@damage 2d6}) fire damage on a failed {@dc 13} Dexterity saving throw."
+                  ]
+                },
+                {
+                  "type": "item",
+                  "name": "Eyeflash",
+                  "entries": [
+                    "The mlox's third eye flashes, adding 2 to its AC against one melee attack that would hit it."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "F",
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Only one thing distinguishes a human from a mlox, and it’s rarely obvious: a mlox can trigger a portion of its forehead to iris open, revealing a mechanical, glowing “third eye.” But mloxan are secretive, not given to revealing their odd anatomy, their history, or why they hide in human form. Mloxan are particularly suspicious of machine creatures and give them as wide a berth as possible, especially drones of {@footnote Peerless||Peerless, page 214}.",
+              {
+                "type": "entries",
+                "name": "Third Eye and Machine Brain",
+                "entries": [
+                  "Most mloxan avoid conflict. If forced to fight, they do so with normal weapons and are slightly more robust than an average human, but nothing special—that is, until a mlox opens its third eye. When it does so, it makes a direct connection with the surrounding environment and gains several abilities.",
+                  "If a mlox is slain and dissected, its third eye is revealed to be the leading edge of a mechanical brain that occupies the skull space normally filled by a biological one."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Hiding in Plain Sight",
+                "entries": [
+                  "Mloxan try to be easy-going and agreeable because they don’t want to draw attention to themselves. If found out, a mlox will promise much to a PC in return for keeping its secret. Or, it may decide that the best way to ensure that a character stays quiet is to eliminate them, especially if they seem to be negotiating in bad faith. On the other hand, during some desperate moment, an NPC the characters assumed to be a regular person could open their third eye to resolve the situation, revealing a previously unknown ability, and potentially that the NPC is a mlox."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "We have no way of knowing how long the mloxan have been walking among us. The release of the numenera into the world again may have been the start of it, or they may have quietly slipped out of stasis and into our villages a long time ago. The ones I know of appear human, and are trustworthy folk, but there may be others who look like humans, dwarves, elves, or even vile creatures such as drow and orcs, and may have very different agendas that are yet to be revealed."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_204_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_204_Image_0002.png"
+    },
+    {
+      "name": "Murden",
+      "source": "AotA",
+      "page": 204,
+      "size": "M",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "murden"
+        ]
+      },
+      "alignment": [
+        "L",
+        "NX",
+        "C",
+        "NY",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "{@item leather armor|PHB}"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 37,
+        "formula": "7d8 + 6"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 16,
+      "dex": 14,
+      "con": 12,
+      "int": 10,
+      "wis": 13,
+      "cha": 14,
+      "skill": {
+        "deception": "+4",
+        "persuasion": "+4",
+        "damageimmunities": "psychic"
+      },
+      "senses": [
+        "darkvision 30 ft."
+      ],
+      "passive": 11,
+      "conditionImmune": [
+        "charmed",
+        "frightened"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Murden Cynicism",
+          "entries": [
+            "The murden has advantage on saving throws against being {@condition charmed} or {@condition frightened}."
+          ]
+        },
+        {
+          "name": "Mental Hiss",
+          "entries": [
+            "Although inadvertent, the murden's inherent telepathic powers are irritating and harmful to nearby creatures, who perceive it as an annoying static that scrambles thought. When a creature starts its turn within 30 feet of a murden who is not {@condition incapacitated}, the creature must succeed on a {@dc 14} Wisdom saving throw or gain disadvantage on all attacks, saves, and checks, which persists until it moves more than 30 feet from the murden."
+          ]
+        },
+        {
+          "name": "Poison Weapon",
+          "entries": [
+            "If the murden has a moment to prepare, such as when preparing an ambush, it poisons its blade. The first hit with the blade that deals damage also requires that the target succeed on a {@dc 14} Constitution saving throw or take 7 ({@damage 2d6}) poison damage in addition to the weapon's normal damage."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The murden makes two attacks, either with its scimitar-like blade or its sling. When possible, they attack from the shadows with ambushes and hit-and-run tactics.",
+            "They normally flee in the face of real danger."
+          ]
+        },
+        {
+          "name": "Scimitar",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) slashing damage."
+          ]
+        },
+        {
+          "name": "Sling",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range 150/600 ft., one target. {@h}2 ({@damage 1d4 + 2}) bludgeoning damage."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "B",
+        "I",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RNG",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Those who have experienced a murden’s telepathic white noise firsthand report that strange voices and long-forgotten memories sometimes arise in the mental interference in haunting and disturbing ways."
+                    ]
+                  }
+                ]
+              },
+              "Murdens walk upright but would never be mistaken for humans. Backs hunched dramatically forward, skin covered in shiny black down, huge black eyes perched above a sharp, dirty yellow beak— {@footnote these things seem almost like enormous ravens with spindly arms rather than wings|Murden claim to originate in a parallel plane of existence, one not previously accessible until the first Ancients’ cache opened.}. Tattered leather cloaks cover their backs, and many carry a leather bag or wear one on a strap to hold the various objects they have collected.",
+              {
+                "type": "entries",
+                "name": "Voiceless Schemers",
+                "entries": [
+                  "Murdens don’t speak. They communicate with one another telepathically. However, their telepathy annoys other intelligent creatures. The presence of a living murden fills the minds of nearby creatures with a sort of mental hiss. Add this irritation to their paranoid mindset, their cruelty, their selfishness, and their duplicitous, scheming nature, and there is little to like about a murden.",
+                  "Those who have experienced a murden’s telepathic white noise firsthand report that strange voices and long-forgotten memories sometimes arise in the mental interference in haunting and disturbing ways.",
+                  "Communicating with murdens is very difficult, but they seem to understand at least a little of other languages they come across and can convey information through gestures or drawings in the sand. Trusting them, however, is a fool’s mistake, for a murden delights in lies and trickery for their own sake."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Many wonders of the Ancients I’ve preferred to these murden. Their bright eyes, their tools, and their use of the numenera indicate intelligence, but they don’t speak. Their features put me in mind of crows, though I’ve always found crows pleasant. These creatures troubled me. The harmony of my thoughts, normally so comforting, grows more scrambled the closer I approach."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Then don’t approach."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_207_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_207_Image_0002.png"
+    },
+    {
+      "name": "Nalurus",
+      "source": "AotA",
+      "page": 206,
+      "size": "M",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "usually human"
+        ]
+      },
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 52,
+        "formula": "8d8 + 16"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 16,
+      "dex": 11,
+      "con": 15,
+      "int": 12,
+      "wis": 11,
+      "cha": 7,
+      "passive": 10,
+      "languages": [
+        "Common",
+        "or whatever language they spoke before infection"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Brain-liquifying Reaction",
+          "entries": [
+            "If a creature starts its turn within 30 feet of the nalurus and the victim can see the nalurus's face, the creature must succeed on a {@dc 12} Constitution saving throw, or they suffer a massive headache and begin to drip pink froth from their nose; they have disadvantage on all checks, saves, and attacks. The victim must repeat the saving throw at the end of their next turn. On a success, the effect ends and the victim escapes with only 14 ({@damage 4d6}) necrotic damage. On a failure, the creature's brain completely liquifies, killing it.",
+            "A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the nalurus's face until the start of its next turn, when it can avert its eyes again. If it looks at the nalurus in the meantime, it must immediately make the save.",
+            "A nalurus is immune to seeing itself in a mirror; it already survived the information plague that rendered it simply as a carrier."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Staff",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) bludgeoning damage."
+          ]
+        }
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "B",
+        "N"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "t wasn’t pretty. I found them lying dead in puddles of pink slime. Looked as if they’d vomited their brains out."
+                    ],
+                    "by": "Bystander"
+                  }
+                ]
+              },
+              "A nalurus always wears a hood or mask. It may be pretending, even to itself, that it’s still human, despite the terrible infection it survived but still carries. The nalurus transmits its infection by sight. {@footnote If a humanoid sees a nalurus without its hood and looks full upon the disquieting lines, spirals, and geometric shapes laid out in ridges across the creature’s face|A slain nalurus remains as dangerous to look upon as a live one for about one day, after which the ridges slump and rot, making the corpse’s head merely ugly and dead as opposed to lethal and dead.}, the awful pattern imprints on the victim’s mind. Something in the interplay of information, refraction, and the physical structure of the victim’s brain sets off a cruel and rapid chain reaction. What begins as a pinkish nose drip ends when the victim’s brain completely liquefies and exits the victim’s head from the eyes, nose, mouth, and ears less than a minute after the infection occurs.",
+              {
+                "type": "entries",
+                "name": "Solitude Seekers",
+                "entries": [
+                  "A nalurus seeks solitude, but over time, that very solitude can drive the creature to take risks with the safety of others by seeking out their company. A nalurus that remains alone for too long can go insane, becoming {@footnote a paranoid murderer that shows off its face at the first opportunity|The nalurus doesn’t have to be aware of a victim to affect it. A nalurus can be incapacitated or even dead (for up to one day) and still affect humanoids who see its face with its Brain-liquifying Reaction.}. A nalurus that hasn’t gone insane from loneliness is usually angry at being disturbed, discourteously blunt, and quick to send visitors on their way. A kind act or gift can soften the creature’s manner, but doesn’t change things."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Eccentric Old Hermit",
+                "entries": [
+                  "The PCs are asked to deal with a man at the edge of town who has started stealing food and scaring the children. Most people in the community are apprehensive about the recluse because of stories of a decades-old plague that only he survived."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_208_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_208_Image_0002.png"
+    },
+    {
+      "name": "Nevajin",
+      "source": "AotA",
+      "page": 207,
+      "size": "M",
+      "type": "monstrosity",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        18
+      ],
+      "hp": {
+        "average": 32,
+        "formula": "5d8 + 10"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 14,
+      "dex": 14,
+      "con": 14,
+      "int": 15,
+      "wis": 14,
+      "cha": 11,
+      "save": {
+        "dex": "+2",
+        "con": "+4",
+        "wis": "+2",
+        "cha": "+2"
+      },
+      "skill": {
+        "arcana": "+4",
+        "perception": "+2"
+      },
+      "senses": [
+        "blindsight 10 ft.",
+        "darkvision 60 ft."
+      ],
+      "passive": 12,
+      "immune": [
+        "fire",
+        "lightning"
+      ],
+      "languages": [
+        "Common",
+        "various others"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Device Use",
+          "entries": [
+            "A nevajin always has a couple of offensive and defensive devices concealed about its body. Those advantages are already figured into the nevajin's stat block. However, a nevajin may also have a one-use cypher that allows it to turn {@condition invisible} or teleport up to 500 ft. away to escape attack, which it uses if its split ability fails to save at least one part of it."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Lightning Ray",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, range 120 ft., one target. {@h}20 ({@damage 3d10 + 2}) lightning damage."
+          ]
+        }
+      ],
+      "reaction": [
+        {
+          "name": "Split",
+          "entries": [
+            "The nevajin splits its head from its body after taking damage it feels is egregious (half or more of its total), becoming two creatures: a hovering head and a headless body. Both have effectively the same stats as a single nevajin, except the head has a fly speed of 60 feet (hover). One attempts to flee, while the other provides a distraction.",
+            "Usually, it's the head that flies away."
+          ]
+        }
+      ],
+      "senseTags": [
+        "B",
+        "D"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "L"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "The nevajin is not a single creature, but two. It looks like a stocky, bent-over humanoid or a crouching predatory beast with a misshapen, almost skull-like head. But the head is actually a separate creature that adheres to the main body by means of connecting filaments and telekinetic force. When joined, the two portions infuse each other with filaments that allow an exchange of information and nutrients. Separation is a painful process that the nevajin does not undertake lightly. Both portions of the nevajin have their own brains, sensory organs, and digestive systems.",
+              {
+                "type": "entries",
+                "name": "Curious Specimen",
+                "entries": [
+                  "Nevajin do not appear to age, and their method of reproduction is a mystery. The nevajin might be asexual, with each portion budding at the same time to create a new joined creature. But as weird as these creatures are, they seem to find the world in which they find themselves even more curious. They are constantly seeking new information and experiences."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Purveyors of Knowledge",
+                "entries": [
+                  "Nevajin are fairly intelligent and speak many languages in their harsh, whispery voices. Nevajin are sources of information and interesting relics of the past. When a secret bit of knowledge is needed, the PCs must travel deep into the wilderness to find the nevajin that possesses it. They can provide a great deal of information about the numenera, but they expect to be paid for their secrets, usually in the form of items, or new information."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_209_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_209_Image_0002.png"
+    },
+    {
+      "name": "Neveri",
+      "source": "AotA",
+      "page": 208,
+      "size": "H",
+      "type": "monstrosity",
+      "alignment": [
+        "C",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 16,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 175,
+        "formula": "17d12 + 64"
+      },
+      "speed": {
+        "walk": {
+          "number": 50,
+          "condition": "(hover)"
+        }
+      },
+      "str": 24,
+      "dex": 17,
+      "con": 18,
+      "int": 9,
+      "wis": 14,
+      "cha": 12,
+      "senses": [
+        "blindsight 90 ft."
+      ],
+      "passive": 16,
+      "resist": [
+        "acid",
+        "cold",
+        "fire",
+        "lightning",
+        "thunder",
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks"
+        }
+      ],
+      "immune": [
+        "necrotic",
+        "poison"
+      ],
+      "languages": [
+        "picks up new languages telepathically"
+      ],
+      "cr": "11",
+      "trait": [
+        {
+          "name": "Regeneration",
+          "entries": [
+            "The neveri regains 10 hit points at the start of its turn. If it starts its turn with 0 hit points, it continues to regenerate, but does not take an action during the turn it started at 0."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The neveri makes two tendril attacks."
+          ]
+        },
+        {
+          "name": "Tendril",
+          "entries": [
+            "{@atk mw} {@hit 11} to hit, reach 5 ft., one Large or smaller creature. {@h}29 ({@damage 4d10 + 7}) bludgeoning damage and the target is {@condition grappled} (escape {@dc 17}), and is {@condition restrained} until this grapple ends. A neveri can grapple up to two",
+            "Medium (or smaller) or one Large creature at one time."
+          ]
+        },
+        {
+          "name": "Attack Organs {@recharge 5}",
+          "entries": [
+            "The neveri creates a transient, specialized organ that sprays acid, spits a flesh-rotting enzyme, or generates a burst of electricity. Treat as a line effect 60 feet long and 5 feet wide. Each creature in that line must make a {@dc 16} Dexterity saving throw, taking 66 ({@damage 12d10}) damage (either acid, necrotic, or lightning) on a failed save, or half as much damage on a successful one."
+          ]
+        },
+        {
+          "name": "Engulf",
+          "entries": [
+            "The neveri attempts to engulf a {@condition grappled} target, who must succeed on a {@dc 16} Strength saving throw, or be engulfed, ending the grapple. While engulfed, the target is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the neveri, and it takes 21 ({@damage 6d6}) acid damage at the start of each of the neveri's turns. A neveri can have only one creature swallowed at a time.",
+            "If the neveri takes 30 damage or more on a single turn from the swallowed creature, the neveri must succeed on a {@dc 14} Constitution saving throw at the end of that turn or regurgitate the creature, which falls {@condition prone} in a space within 10 feet of the neveri. If the neveri starts a turn with 0 hit points, a swallowed creature is no longer {@condition restrained} by it and can escape from the temporary corpse by using 15 feet of movement, exiting {@condition prone}."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Regeneration"
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack",
+        "Swallow"
+      ],
+      "damageTags": [
+        "A",
+        "B"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "blinded",
+        "grappled",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A neveri is a floating blob of heaving, writhing flesh, 15 feet in diameter, apparently rotting and always oozing pus, dark fluids, and the odor of a thousand graves. A neveri constantly extrudes new sections of skin, mouths, eyes, spines, clawed hands, and whipping tendrils, seemingly force-grown from the mass of dead matter that serves as the nucleus of its body.",
+              {
+                "type": "entries",
+                "name": "",
+                "entries": [
+                  "Neveri were secured by the Ancients in various forgotten prisons. But why? Why didn’t the Ancients simply destroy the neveri? Many possibilities suggest themselves, but the plainest answer might be because {@footonte even the Ancients could not devise a method to kill them.|The only way to stop a neveri is by confining it or shunting it into an ultimate region of destruction, such as the sun}",
+                  "Thankfully extremely rare, neveri apparently spend years at a time either inactive or imprisoned from some earlier epoch. When one becomes active (or escapes), it makes a lair in a hard-to-reach location within a day or two of a large population of living things and sets to work feeding its ravenous appetite."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Aware",
+                "entries": [
+                  "A neveri has a low-level telepathic ability that allows it to sense when living creatures come near and perhaps pick up bits of the thinking creature’s language. It responds to attempts at communication by forming a mouth that issues horrifying threats. Then it attacks."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "When the gods—or as in this case, the Ancients—imprison a powerful evil thing rather than destroy it, I always wonder why. I’ve developed several possible reasons:",
+                      "• Death would release the slain thing to reincarnate at an unknown time and place;",
+                      "• Moral reluctance;",
+                      "• The thing’s potential use as a weapon;",
+                      "• The thing is linked with its imprisoners, so that to slay one slays both;",
+                      "• Death would be too easy; the jailors want the thing eternally punished;",
+                      "• Or, as is apparently the case for the neveri, it’s impossible for the thing to actually die"
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_211_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_211_Image_0002.png"
+    },
+    {
+      "name": "Ojj",
+      "source": "AotA",
+      "page": 210,
+      "size": "L",
+      "type": "elemental",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        17
+      ],
+      "hp": {
+        "average": 375,
+        "formula": "30d10 + 210"
+      },
+      "speed": {
+        "walk": 30,
+        "fly": {
+          "number": 30,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 15,
+      "dex": 15,
+      "con": 25,
+      "int": 25,
+      "wis": 20,
+      "cha": 20,
+      "save": {
+        "int": "+15",
+        "wis": "+13",
+        "cha": "+13"
+      },
+      "skill": {
+        "deception": "+13",
+        "intimidation": "+13",
+        "perception": "+13"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 23,
+      "resist": [
+        "acid",
+        "bludgeoning",
+        "cold",
+        "fire",
+        "lightning",
+        "necrotic",
+        "piercing",
+        "psychic",
+        "radiant",
+        "slashing",
+        "thunder"
+      ],
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "poisoned",
+        "prone"
+      ],
+      "languages": [
+        "telepathy 1 mile"
+      ],
+      "cr": "25",
+      "trait": [
+        {
+          "name": "Energy Form",
+          "entries": [
+            "The ojj can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the ojj or hits it with a melee attack while within 5 feet of it takes 10 ({@damage 2d10}) psychic damage. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes 5 ({@damage 1d10}) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+          ]
+        },
+        {
+          "name": "Mind Sense",
+          "entries": [
+            "An ojj automatically senses the presence of all minds within its telepathy range unless the minds are behind a force field."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The ojj fires two psychic blasts, uses two unique abilities, or one psychic blast and one unique ability."
+          ]
+        },
+        {
+          "name": "Psychic Blast",
+          "entries": [
+            "{@atk rw} {@hit 15} to hit, range 100/200 ft., one target. {@h}62 ({@damage 10d10 + 7}) force damage or 51 ({@damage 8d10 + 7}) psychic damage."
+          ]
+        },
+        {
+          "name": "Unique Abilities",
+          "entries": [
+            "Ojj have advanced psychic powers. Each ojj usually has four of the following abilities, and may have one additional ability unique to that individual.",
+            "Unless otherwise stated, these abilities require a direct line of sight to the target. Effects listed here that duplicate spells are nonmagical numenera psychic abilities. If the effect would normally have a saving throw, it is a {@dc 21} Wisdom save.",
+            "• {@spell Dominate monster}, except limited to a 500-foot range. Depending on the ojj, a controlled target can attempt to break free every round, every minute, every hour, every day, or every few days. This control usually manifests as a visible colored halo around the head of the target.",
+            "• {@spell Detect thoughts}, except affecting up to five creatures within 60 feet.",
+            "• Deal 2 ({@damage 1d4}) psychic damage to a creature within 500 feet, even if it has no direct line of sight to that creature.",
+            "• {@spell Telekinesis}, except the weight limit is 200 pounds and the range is 60 feet. If the ojj uses its action doing nothing but telekinesis, it can move up to 400 pounds.",
+            "• Create a vaguely humanoid {@footnote psychic construct|Psychic Construct. Use stats for basic automaton type five.|Basic automaton, page 246}, an automaton made of pure mental energy, that lasts for one minute. The construct obeys the ojj's mental commands and can manipulate physical objects as well as a human can.",
+            "• Increase its AC by +2 until the start of its next turn.",
+            "• Activate, deactivate, or manipulate a numenera device within 60 feet.",
+            "• Drain energy from a numenera relic, installation, or vehicle within 60 feet, restoring 30 hp if uncommon, 50 hp if rare, 75 hp if very rare, or 90 hp if it is legendary. The object must make a depletion roll each time an ojj uses this ability on it.",
+            "• {@spell Imprisonment} (slumber) on a creature within 60 feet, lasting 1 minute.",
+            "• {@spell Wall of force}, except it is a 10-foot square, within 60 feet, lasting 1 minute.",
+            "• {@spell Fabricate}, affecting a 5-foot cube within 60 feet; the ojj can use this ability to perform fine crafting over time, even numenera crafting, given the proper materials.",
+            "• {@spell Major Image}, with the nearest edge within 10 feet, lasting 10 minutes.",
+            "• Alter its psychic blast to deal cold, fire, lightning, radiant, or thunder damage instead of psychic damage.",
+            "• Heal 10 points of damage to a creature other than itself within 60 feet.",
+            "• {@spell Teleport} itself and up to three other Medium creatures up to 1 mile away."
+          ]
+        },
+        {
+          "name": "Unique Augmentations",
+          "entries": [
+            "Instead of one of the above abilities, an ojj might have one of the following augmentations to one of its abilities:",
+            "• The ability's range increases by one category (60 feet to 100 feet, 100 feet to 500 feet, 500 feet to 1 mile, 1 mile to 5 miles). This doesn't affect the sight requirements for the ability.",
+            "• The ability can affect targets that aren't within the ojj's line of sight. This doesn't affect the range of the ability.",
+            "• The ability can be used once per round without counting toward the normal limitation of two abilities per action."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "TP"
+      ],
+      "damageTags": [
+        "F",
+        "O",
+        "Y",
+        "R",
+        "C",
+        "L",
+        "T"
+      ],
+      "miscTags": [
+        "AOE",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Ojj are powerful energy beings left over from the ancient past. Most were imprisoned and buried long ago by advanced numenera-wielding civilizations that couldn’t quite destroy them. These hateful things have been silently fuming for aeons, but a few have picked at the locks of their cages long enough to allow them limited access to the outer world, which they use to lure beings with lies, threats, and promises of great rewards in exchange for their freedom.",
+              {
+                "type": "entries",
+                "name": "Advanced Telepaths",
+                "entries": [
+                  "Ojj are naturally telepathic and can mentally communicate to a range of about 1 mile, even speaking simultaneously to dozens or hundreds of people."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Malevolent",
+                "entries": [
+                  "Ojj enjoy dominating others, inflicting pain, and flattery. They act as if they are gods and expect weaker beings to worship them. They place little value on the lives of physical beings and act only in the interest of their power and ego. They are very dangerous foes and can cause a lot of destruction if allowed to move freely. An imprisoned or weakened one might present itself as a god to a cult or tribe of humanoids, demanding sacrifices and torture in its name."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage",
+                "entries": [
+                  "The afterimages of an ojj’s death might coalesce into {@dice 1d6} energy- based cyphers and one or two energy-based relics. The numenera that imprisoned a now-dead ojj can also be salvaged for {@dice 1d6} additional cyphers."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_212_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_212_Image_0002.png"
+    },
+    {
+      "name": "Oorgolian Soldier",
+      "source": "AotA",
+      "page": 212,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 16,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 45,
+        "formula": "6d10 + 12"
+      },
+      "speed": {
+        "walk": 50
+      },
+      "str": 15,
+      "dex": 12,
+      "con": 13,
+      "int": 14,
+      "wis": 11,
+      "cha": 13,
+      "skill": {
+        "athletics": "+6",
+        "perception": "+2"
+      },
+      "passive": 13,
+      "immune": [
+        "poison",
+        "psychic"
+      ],
+      "vulnerable": [
+        "thunder"
+      ],
+      "conditionImmune": [
+        "blinded",
+        "charmed",
+        "deafened",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "Oorgolian"
+      ],
+      "cr": "2",
+      "trait": [
+        {
+          "name": "Self-detonation",
+          "entries": [
+            "When the soldier dies, it explodes as if the center of one its own detonation thrower attacks. This destroys the built-in, back-mounted detonation thrower, and on a roll of 1-2 on {@dice 1d6}, also destroys the slug-thrower relic."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Oorgolian Slug Thrower",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range 120 ft., one target. {@h}13 ({@damage 2d10 + 2}) piercing damage."
+          ]
+        },
+        {
+          "name": "Detonation Thrower {@recharge 5}",
+          "entries": [
+            "The soldier deploys a back-mounted device that hurls a detonation up to 120 feet.",
+            "Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 11} Dexterity saving throw or take 21 ({@damage 6d6}) fire damage on a failed save, or half as much damage on a successful one."
+          ]
+        }
+      ],
+      "damageTags": [
+        "F",
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "RW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Another wonder fashioned by the Ancients, the mechanical entities known as Oorgolian soldiers patrol isolated areas for reasons unknown, possibly anticipating another cache of the Ancients appearing nearby. They are almost always found in groups of five or seven. Lanky and alien in their movements, these quasi-humanoid automatons stand almost 8 feet tall. They wield a variety of weapons.",
+              {
+                "type": "entries",
+                "name": "Motivations Lost to Time",
+                "entries": [
+                  "No one knows the origin of the word “Oorgolian.” It is thought to be a term from a tongue used by the Ancients, and so now long dead. On their own, Oorgolians act on prior orders that literally may be a million years old or more, so their actions and motives don’t always make sense. Sometimes they completely ignore creatures they find. Sometimes they attempt to communicate in their own language. Sometimes they ambush and attack."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Oorgolians act on prior orders that literally may be a million years old or more, so their actions and motives don’t always make sense."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Potential Allies",
+                "entries": [
+                  "At least one mercenary leader, with the help of those who’d made a study of arcana of the Ancients, has captured and repurposed a number of Oorgolian soldiers, probably using sound. These soldiers remember nothing of their former duties and work for their new masters."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Powerful Treasure (Salvage)",
+                "entries": [
+                  "Oorgolian soldiers carry relic weapons called Oorgolian slug throwers. In addition, each Oorgolian body contains {@dice 1d6} cyphers."
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "These are soldiers after my own heart. Maybe they don’t know what they’re fighting for anymore. Maybe what they’re fighting for is long dead! But they fight anyway. And look at their discipline! Still patrolling, still training, still maintaining their weapons. If I’d had a company like this back in the day, my clan would never have lost the Delve..."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "I’m sorry that memory brings you such pain, Faim. But take comfort. These Oorgolians would have likely refused to help, or worse, taken the Delve for their own"
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_214_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_214_Image_0002.png"
+    },
+    {
+      "name": "Peerless",
+      "isNamedCreature": true,
+      "source": "AotA",
+      "page": 214,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 75,
+        "formula": "10d8 + 30"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 18,
+      "dex": 11,
+      "con": 16,
+      "int": 12,
+      "wis": 10,
+      "cha": 14,
+      "senses": [
+        "blindsight 60 ft.",
+        "darkvision 120 ft."
+      ],
+      "passive": 13,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "blinded",
+        "charmed",
+        "deafened",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "languages": [
+        "telepathy 120 ft. (only with other machines)",
+        "can quickly learn most verbal languages"
+      ],
+      "cr": "5",
+      "trait": [
+        {
+          "name": "Machine Focused",
+          "entries": [
+            "When Peerless uses Inveigle or Spawn New",
+            "Instance, constructs and machines have disadvantage on their saves; all other creatures have advantage."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "Peerless has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magic Weapons",
+          "entries": [
+            "Peerless's weapon attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "Peerless makes two claws attacks."
+          ]
+        },
+        {
+          "name": "Claws",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d4 + 4}) slashing damage."
+          ]
+        },
+        {
+          "name": "Inveigle",
+          "entries": [
+            "One creature within 60 feet must succeed on a {@dc 13} Wisdom saving throw or be {@condition charmed} by Peerless for 1 hour or until Peerless does something harmful to them. The {@condition charmed} creature is friendly and helpful to Peerless, but after the effect ends, they know that their inclinations were manipulated."
+          ]
+        },
+        {
+          "name": "Spawn New Instance {@recharge}",
+          "entries": [
+            "One creature chosen by Peerless within 30 feet that is currently or has previously succumbed to Inveigle must succeed on a {@dc 13} Constitution saving throw or be infected with a machine disease called Peerless. While infected, the target can't regain hit points, and its hit point maximum is reduced by 10 ({@dice 3d6}) every 24 hours. If the target is a living creature, during this period their biological parts are observed to be slowly replaced by machine components. If the disease reduces the target's hit point maximum to 0, the target instantly transforms into another instance of Peerless. If the disease is halted before it goes to completion, a biological creature's body rejects the artificial parts, and regains maximum hit points at the same rate they were lost."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Magic Resistance",
+        "Magic Weapons"
+      ],
+      "senseTags": [
+        "B",
+        "SD"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "TP"
+      ],
+      "damageTags": [
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "charmed"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Peerless is a machine creature that exists in multiple construct bodies, sometimes {@footnote taking over other machines to duplicate more versions of itself, erasing any personality or goals that may have previous existed|A cypher or relic the PC carries with the potential to host even a limited machine intelligence might be briefly infected with Peerless. It begins to speak as Peerless and work against the PC however it can for a day, after which the instance of Peerless, finding the item too small to hold it, erases itself.}. All it cares about is spreading itself as far and wide as possible. It is Peerless.",
+              {
+                "type": "entries",
+                "name": "Fearless Narcissist",
+                "entries": [
+                  "Those have encountered instances of Peerless describe the construct as bloodthirsty, single-minded, and a bit unstable; each individual construct claims that it is Peerless, the source mind from which all others are made. Even newly converted machines and constructs say the same. This begs the question of where the originating intelligence of Peerless actually resides—maybe in a hidden ruin, as a consciousness in some nearby but unseen dimension, or as a mind distributed across every connected construct."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Prejudiced Against Flesh",
+                "entries": [
+                  "An individual Peerless construct ignores biological creatures if there are constructs or machines to be interacted with. However, if there is no choice but to interact with a living creature, Peerless may establish verbal communication. In such cases, it comes across as over-the-top pompous and self-important, always refering to itself as Peerless. Although Peerless isn’t worried about risking any particular instance of itself in combat, it will forgo conflict in return for information about the location of other machines, especially {@creature mlox|aota|mloxan}. However, if a PC happens to be part machine, all bets are off, because Peerless will be keen to convert them. (Purely biological creatures may face the same issue, though only if Peerless is feeling experimental.)"
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "The arrogance is what astonishes me most. And the lack of need for someone other than itself, only and forever. Having no one else to interact with would drive most creatures mad. Though perhaps that is exactly what happened, aeons ago."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_217_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_217_Image_0002.png"
+    },
+    {
+      "name": "Philethis",
+      "source": "AotA",
+      "page": 217,
+      "size": "M",
+      "type": "aberration",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 146,
+        "formula": "17d8 + 72"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 16,
+      "dex": 16,
+      "con": 18,
+      "int": 18,
+      "wis": 15,
+      "cha": 19,
+      "skill": {
+        "perception": "+7",
+        "stealth": "+8"
+      },
+      "senses": [
+        "truesight 120 ft."
+      ],
+      "passive": 17,
+      "resist": [
+        "cold",
+        "fire",
+        "lightning",
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks"
+        }
+      ],
+      "immune": [
+        "poison",
+        "psychic"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "frightened",
+        "poisoned"
+      ],
+      "languages": [
+        "any it encounters"
+      ],
+      "cr": "13",
+      "trait": [
+        {
+          "name": "Legendary Resistance (3/Day)",
+          "entries": [
+            "If the philethis fails a saving throw, it can choose to succeed instead."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The philethis has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magic Weapons",
+          "entries": [
+            "The philethis' weapon attacks are treated as if magical."
+          ]
+        },
+        {
+          "name": "New Instance",
+          "entries": [
+            "A destroyed philethis reforms elsewhere in {@dice 2d6} days, regaining all its hit points and becoming active again.",
+            "The new body appears inside a previously keyed machine of the Ancients."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The philethis can use its Stare of the Aeons, and make three {@condition invisible} force blade attacks."
+          ]
+        },
+        {
+          "name": "Invisible Force Blade",
+          "entries": [
+            "{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d10 + 3}) slashing damage."
+          ]
+        },
+        {
+          "name": "Stare of the Aeons",
+          "entries": [
+            "The philethis focuses on one creature it can see within 30 feet of it. Whether or not the target can see the philethis, the target must succeed on a {@dc 17} Wisdom saving throw or be {@condition stunned} until the end of the philethis' next turn. If the target's saving throw is successful, the target is immune to the philethis' stare for the next 24 hours."
+          ]
+        },
+        {
+          "name": "Teleport",
+          "entries": [
+            "The philethis teleports, along with any equipment it is wearing or carrying, up to 500 feet to an unoccupied space it can see."
+          ]
+        }
+      ],
+      "legendary": [
+        {
+          "name": "Invisible Force Blade",
+          "entries": [
+            "The philethis makes an {@condition invisible} force blade attack."
+          ]
+        },
+        {
+          "name": "Teleport (Costs 2 Actions)",
+          "entries": [
+            "The philethis uses a teleport action."
+          ]
+        },
+        {
+          "name": "Stare of the Aeons (Costs 3 actions)",
+          "entries": [
+            "The philethis makes a",
+            "Stare of the Aeons attack."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Legendary Resistances",
+        "Magic Resistance",
+        "Magic Weapons"
+      ],
+      "senseTags": [
+        "U"
+      ],
+      "actionTags": [
+        "Multiattack",
+        "Teleport"
+      ],
+      "damageTags": [
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Of all the strange creatures that appeared in conjunction with the caches of the Ancients opening, few are more mysterious than philethis. It’s not even known for sure if they come from the caches, or if they were simply attracted to the event from somewhere else entirely. Some even wonder if they are not Ancients themselves, as all seem to have a far greater mastery of numenera than anything else.",
+              "No one has seen the entire body of a philethis and reported what they saw, but the glimpses noted to date suggest a biomechanical hybrid form. Typically what is seen is a metal and glass “face” surrounded by voluminous cloaks.",
+              {
+                "type": "entries",
+                "name": "Mysterious",
+                "entries": [
+                  "Other speculation about the philethis includes claims that they are constructs, that they are demons, that they are tiny dimensions unto themselves, and/or that their “face” is actually a viewport for a creature beyond space and time. Most theories about their nature don’t even guess at what their goals or motivations might be. {@footnote They appear when and where they want to, and they usually seem to observe events from a distance |Something unexpected and unpredictable might happen when the philethis is near. The event should be small, but result in a significant change. For example, the PC slips and falls into a 10-foot-deep pit, suffering damage, but then finds something of great interest at the bottom.} (although another theory suggests that they influence the events somehow)."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Mysterious",
+                "entries": [
+                  "Philethis are not hostile (though aggressively defend themselves if attacked). If engaged in conversation, they might respond in their strange, machinelike voices, speaking in the native language of whomever they talk to. However, such interchanges usually make a philethis more enigmatic rather than less. Their explanations for things rarely make sense, and the questions they ask seem unrelated to anything going on around them. A typical philethis interaction might go as follows:",
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Human: Who are you and what are you doing here?",
+                      "Philethis: The moon is full, and the roses will bloom in 437 hours.",
+                      "Human: What are you talking about?",
+                      "Philethis: When you were eleven years old and playing with that ball, why did you bounce it three times against the wall but four times against the ground?",
+                      "Human: How do you know anything about when I was a child?",
+                      "Philethis: The galaxies will collide soon. We must prepare."
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Always One Step Ahead",
+                "entries": [
+                  "Philethis are meant to be an enigma. Players (and their characters) should never fully understand the creatures, and if they believe that they do, something should happen to show that they are wrong. Moreover, the PCs should find out at odd times and in odd ways that the philethis are involved—or at least appear to be involved—in surprising situations. Are they just observing, or are they manipulating events somehow? And if so, why? The quest for this knowledge could be the basis for an entire campaign."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_219_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_219_Image_0002.png"
+    },
+    {
+      "name": "Plasmar",
+      "source": "AotA",
+      "page": 218,
+      "size": "M",
+      "type": "elemental",
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 85,
+        "formula": "11d8 + 36"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 11,
+      "dex": 12,
+      "con": 12,
+      "int": 19,
+      "wis": 17,
+      "cha": 17,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 10,
+      "resist": [
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks"
+        }
+      ],
+      "immune": [
+        "fire",
+        "poison"
+      ],
+      "conditionImmune": [
+        "exhaustion",
+        "grappled",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "prone",
+        "restrained",
+        "unconscious"
+      ],
+      "languages": [
+        "Plasmar"
+      ],
+      "cr": "7",
+      "trait": [
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The plasmar has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Plasma Form",
+          "entries": [
+            "A creature that touches the plasmar or hits it with a melee attack while within 5 feet of it takes 5 ({@damage 1d10}) fire damage and 5 ({@damage 1d10}) lightning damage, and catches fire; until someone takes an action to douse the fire, the creature takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+          ]
+        },
+        {
+          "name": "Regeneration",
+          "entries": [
+            "The plasmar regains 10 hit points at the start of its turn, {@footnote if on its home turf, which is typically near (within 500 feet) of some potent energy source|In areas of particularly strong energy fields (strong enough to possibly hurt regular creatures), plasmar might regenerate even more hit points per round and double or triple their maximum hit points.}. If it starts its turn with 0 hit points, it doesn't regenerate."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Touch",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one creature. {@h}15 ({@dice 2d10 + 4}) fire (half) and lightning (half) damage. Targets must succeed on a {@dc 15} Constitution saving throw or be {@condition stunned} until the end of their next turn. Finally, the target catches fire; until someone takes an action to douse the fire, the creature takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+          ]
+        },
+        {
+          "name": "Welding Touch",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one {@condition stunned} humanoid. {@h}28 ({@damage 5d10}) fire damage plus 28 ({@damage 5d10}) lightning damage."
+          ]
+        },
+        {
+          "name": "Plasma Blast {@recharge 5}",
+          "entries": [
+            "The plasmar emits plasma (fire and lightning) in a 100-foot-long, 5-foot-wide line. Each creature in that area must succeed on a {@dc 15} Dexterity saving throw or take 13 ({@damage 2d8 + 4}) fire damage plus 13 ({@dice 2d8} +",
+            "4) lightning damage and be {@condition stunned} until it succeeds on a saving throw at the end of each of its turns. Finally, the target catches fire; until someone takes an action to douse the fire; the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+          ]
+        },
+        {
+          "name": "Ride the Lightning {@recharge 5}",
+          "entries": [
+            "The plasmar becomes a bolt of lightning, along with any equipment it is wearing or carrying, and teleports up to 120 feet to an unoccupied space it can see."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Magic Resistance",
+        "Regeneration"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "damageTags": [
+        "F",
+        "L"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Plasmars are tall, night-black humanoids swaddled in magnetic skins of luminous “liquid fire.” They’re intelligent entities drawn to areas where immense energies are generated or have been recently discharged. They dwell in subterranean tunnels around active volcanoes and in areas rich in Ancients machines that generate the sort of energy fields plasmars depend on to survive. {@footnote Sometimes plasmar scouting parties travel with thunderstorms, looking for new territory.| Plasmars are self-willed and can be strongly territorial, especially if they believe that visitors risk disrupting their energy fields}",
+              {
+                "type": "inset",
+                "entries": [
+                  "Plasmars are not automatically hostile, though they are wary of visitors. Their speech is interspersed with the buzzing and snapping of electrical discharges."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Manifestations of a Sun",
+                "entries": [
+                  "Plasmars are not automatically hostile, though they are wary of visitors. Their speech is interspersed with the buzzing and snapping of electrical discharges. Plasmars view the world differently than regular living creatures do, since they need energy the way that other creatures need air. According to plasmar lore, they originally lived on the surface of a sun that is now long dead and gone."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Storm-tossed Squatters",
+                "entries": [
+                  "A group of plasmars materialized in the aftermath of a recent storm of noteworthy ferocity. The storm is long gone, but the plasmars remain on the crown of a bare hill not far away. A scholar who recently identified the hill as the site of an Ancient’s cache seeks mercenaries to eliminate the “black-cloaked squatters” that are preventing her from exploiting her discovery."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage: Gift of Storm",
+                "entries": [
+                  "Sometimes plasmars give a plasma detonation cypher as a gift."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_220_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_220_Image_0002.png"
+    },
+    {
+      "name": "Progenitor",
+      "source": "AotA",
+      "page": 221,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 16,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 126,
+        "formula": "11d10 + 66"
+      },
+      "speed": {
+        "walk": 20,
+        "swim": 40
+      },
+      "str": 25,
+      "dex": 11,
+      "con": 22,
+      "int": 10,
+      "wis": 13,
+      "cha": 9,
+      "skill": {
+        "perception": "+5"
+      },
+      "senses": [
+        "blindsight 120 ft.",
+        "darkvision 120 ft."
+      ],
+      "passive": 15,
+      "resist": [
+        "bludgeoning",
+        "cold"
+      ],
+      "languages": [
+        "telepathy 500 ft. (among progenitors and its young)"
+      ],
+      "cr": "9",
+      "trait": [
+        {
+          "name": "Water Breathing",
+          "entries": [
+            "The progenitor can breathe only underwater."
+          ]
+        },
+        {
+          "name": "Water Predator",
+          "entries": [
+            "The progenitor has advantage on Dexterity (Stealth) checks made to hide in water."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The progenitor can use Mothering and makes two claw attacks."
+          ]
+        },
+        {
+          "name": "Claw",
+          "entries": [
+            "{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}35 ({@damage 8d6 + 7}) slashing damage."
+          ]
+        },
+        {
+          "name": "Mothering",
+          "entries": [
+            "The progenitor targets one creature it can sense within 30 feet of it. The target must succeed on a {@dc 18} Constitution saving throw or take 3 ({@damage 1d6}) psychic damage and then be affected either by fear or calm love, depending on what the progenitor chooses.",
+            "If filled with fear, the target becomes {@condition frightened} for 1 minute. An affected target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the progenitor's fear for the next 24 hours.",
+            "If filled with calm love, the target is {@condition charmed}, and moves toward the progenitor with open arms, all defenses lowered on their next turn. The progenitor's next two Claw attacks against the affected target automatically succeed and inflict maximum damage. This ends the calm love effect, and the creature is immune to the progenitor's calm love for the next 24 hours."
+          ]
+        },
+        {
+          "name": "Eggburst",
+          "entries": [
+            "The progenitor's young hatch from her belly pouch, swarming all foes in a 20-foot-radius sphere centered on the progenitor with progenitor larva. Targets in the area must succeed on a {@dc 18} Constitution saving throw or take 45 ({@damage 10d8}) piercing damage, or half that if successful. Afterward, a {@creature progenitor larva swarm|aota} remains."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Water Breathing"
+      ],
+      "senseTags": [
+        "B",
+        "SD"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "TP"
+      ],
+      "damageTags": [
+        "P",
+        "S",
+        "Y"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW"
+      ],
+      "conditionInflict": [
+        "charmed",
+        "frightened"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "These mermaid-like broodmares hate and fear surface-dwellers, seeing them as wholly alien and incomprehensible. Their life’s goal is to give birth to their young—creatures much like electric eels—and then protect those young from all dangers. Growing to more than 10 feet in height, progenitors look humanlike from a distance. Up close, even through murky water, it is clear that they are dangerous predators—and that’s even before they show their true colors.",
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Mermaids? That’s a stretch.”"
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "I didn’t say they were mermaids. They remind me of mermaids. Certainly, I don’t need to enumerate the similarities? But yes, obviously there are many differences, too. Such as the fact that these progenitors are an order of magnitude older than anything that lives in our seas."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Although the progenitors are tough physical combatants, their real challenge is their field of psychic energy. They can use this to affect the emotions of nearby creatures. The progenitor either fills them with fear, or fills them with calm love. Progenitors can be dangerous foes, even against large groups of PCs. They are scary creatures to encounter in any undersea adventure, especially in deep water where they are more likely to have larva swarms around them."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_223_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_223_Image_0002.png"
+    },
+    {
+      "name": "Progenitor Larva Swarm",
+      "source": "AotA",
+      "page": 221,
+      "size": "M",
+      "type": {
+        "type": "monstrosity",
+        "swarmSize": "T"
+      },
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        12
+      ],
+      "hp": {
+        "average": 22,
+        "formula": "5d8"
+      },
+      "speed": {
+        "swim": 30
+      },
+      "str": 5,
+      "dex": 15,
+      "con": 10,
+      "int": 2,
+      "wis": 12,
+      "cha": 4,
+      "senses": [
+        "blindsight 60 ft.",
+        "darkvision 60 ft."
+      ],
+      "passive": 11,
+      "resist": [
+        "bludgeoning",
+        "piercing",
+        "slashing"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "frightened",
+        "grappled",
+        "paralyzed",
+        "petrified",
+        "prone",
+        "restrained",
+        "stunned"
+      ],
+      "cr": "1/4",
+      "trait": [
+        {
+          "name": "Swarm",
+          "entries": [
+            "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny eel. The swarm can't regain hit points or gain temporary hit points."
+          ]
+        },
+        {
+          "name": "Water Breathing",
+          "entries": [
+            "The larva swarm can only breathe underwater."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 0 ft., one creature in the swarm's space. {@h}5 ({@damage 2d4}) piercing damage."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Water Breathing"
+      ],
+      "senseTags": [
+        "B",
+        "D"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_223_Image_0002.png"
+    },
+    {
+      "name": "Pygmy Hapax",
+      "source": "AotA",
+      "page": 222,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 81,
+        "formula": "9d10 + 32"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 60,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 16,
+      "dex": 12,
+      "con": 19,
+      "int": 1,
+      "wis": 12,
+      "skill": {
+        "perception": "+3"
+      },
+      "senses": [
+        "blindsight 120 ft."
+      ],
+      "passive": 13,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "poisoned"
+      ],
+      "cr": "3",
+      "trait": [
+        {
+          "name": "Keen Smell",
+          "entries": [
+            "The pygmy hapax has advantage on Wisdom (Perception) checks that rely on smell."
+          ]
+        },
+        {
+          "name": "Color Burst",
+          "entries": [
+            "When a pygmy hapax dies, it explodes in a maelstrom of clashing colors. All creatures in a 20-foot-radius sphere centered on it must succeed on {@dc 13} Dexterity save or take 18 ({@damage 4d8}) necrotic damage, or half that if successful. In the aftermath, 3 ({@dice 1d6}) objects carried by creatures in the blast—or potentially some portion of their anatomy—takes on a bright new hue, possibly even dimly glowing."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The pygmy hapax makes two tendril attacks."
+          ]
+        },
+        {
+          "name": "Tendrils",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 10 ft., one target. {@h}10 ({@damage 2d6 + 3}) piercing damage and the target is {@condition grappled} (escape {@dc 13}; each failed escape attempt further entangles victim, cumulatively increasing escape DC by 1).",
+            "Until this grapple ends, the target is {@condition restrained}, and the pygmy hapax can't use its tendrils on another target. In addition, each round the grapple persists, the color of one object in their possession—or some portion of their anatomy if it carries no unaffected objects—turns black, starting with the brightest. Whether object or anatomy, this deals 10 ({@damage 3d6}) necrotic damage to the {@condition grappled} victim."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Keen Senses"
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "N",
+        "P"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW",
+        "RCH"
+      ],
+      "conditionInflict": [
+        "grappled",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "They came down in great, long streams",
+                      "as if settling to the earth in waves of dreams",
+                      "I reached to touch one, just one, it seems",
+                      "And oh the screams, the screams, the screams"
+                    ],
+                    "by": "Poet unknown (and not very good)"
+                  }
+                ]
+              },
+              "No one can dispute the beauty of the pygmy hapax—at least, no one who has seen the brightly hued, floating creatures coming down to rest upon the earth, their trailing plumages following their descent. They are encountered either soaring in the sky or hovering, always at least a foot above the ground. Pygmy hapax tend to travel in large groups called clouds.",
+              {
+                "type": "entries",
+                "name": "Tendrils of Beauty and Threat",
+                "entries": [
+                  "The tendrils are their true beauty—and their true danger. Each tendril trails nearly 20 feet or longer, and each is covered with millions of small, hollow barbs. Anything that falls into the hapax’s wake—or is purposefully snatched by a billowing tendril—quickly finds itself wrapped into oblivion, its very colors pulled from it as if by a great siphon."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Chromatic Variation Through Diet",
+                "entries": [
+                  "The hapax’s complex color variations come directly from their food source, meaning that the creatures can change color right before your eyes if they’ve recently digested something. Pygmy hapax are always in search of the brightest hues, for those with the most saturated and complex color schemes are more likely to attract a mate."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Hapax Lures",
+                "entries": [
+                  "Pygmy hapax are attracted to brightly colored objects that move and sometimes can be called down from the sky with a proper hapax trap. They might also simply be attracted to colorful creatures that congregate. For instance, a large fight with an animal as bright as a {@creature jiraskar|aota} could draw a cloud of hapax."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Why do they call them pygmy hapax? Where are the regular-sized ones, and how large and bright are they? I question where the lore granted us by the quotien is anything other than an ancient puzzle designed to stymie rather than clarify."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Let’s move away a little, why don’t we? I think they’re pretty, but I don’t like the look of those tendrils. And look, see those branches they were caught on? I don’t think they were glowing blue before."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_225_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_225_Image_0002.png"
+    },
+    {
+      "name": "Tetrahydra",
+      "source": "AotA",
+      "page": 237,
+      "size": "M",
+      "type": "beast",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 33,
+        "formula": "6d8 + 6"
+      },
+      "speed": {
+        "walk": 20,
+        "fly": 120
+      },
+      "str": 17,
+      "dex": 11,
+      "con": 13,
+      "int": 5,
+      "wis": 13,
+      "cha": 6,
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 11,
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The tetrahydra can attack twice, once with its beak and once with its tentacles."
+          ]
+        },
+        {
+          "name": "Beak",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) slashing damage."
+          ]
+        },
+        {
+          "name": "Tentacles",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d6}) bludgeoning damage. If the target is a Medium or smaller creature, it is {@condition grappled} (escape {@dc 13}).",
+            "Until this grapple ends, the tetrahydra automatically squeezes the target for 3 ({@damage 1d6}) bludgeoning damage each round and attacks the {@condition grappled} target twice with its beak, and it has advantage on attack rolls to do so."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack",
+        "Tentacles"
+      ],
+      "damageTags": [
+        "B",
+        "S"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "cr": "2",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "quote",
+                "entries": [
+                  "\"The tetrahydra is clearly a creature of bizarre standing, as it has no feet. Perhaps it stays aloft eternally or lands upon its great beaks to rest.\""
+                ],
+                "by": "Unknown"
+              },
+              "These large creatures, approximately 6 feet tall, look like black-feathered tetrahedrons with beaks and big wings. Tetrahydras have four tentacles that they keep coiled along their lower half. The tentacles uncoil and can be used as feet and weapons.",
+              {
+                "type": "entries",
+                "name": "Nest Protectors. ",
+                "entries": [
+                  "Tetrahydras fight to protect their eggs, which take two years to hatch and are situated in large nests as high up as the creatures can build them. Sometimes they attack alone, but more often they attack in groups of three or more. PCs are likely to run afoul of tetrahydras only if they disturb a nest. However, an NPC skilled in breaking animals to training could have a covey of them serving as attack beasts."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_239_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_239_Image_0002.png"
+    },
+    {
+      "name": "Thuman",
+      "source": "AotA",
+      "page": 238,
+      "size": "M",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "thuman"
+        ]
+      },
+      "alignment": [
+        "N"
+      ],
+      "ac": [
+        10
+      ],
+      "hp": {
+        "average": 13,
+        "formula": "2d8 + 4"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 13,
+      "dex": 10,
+      "con": 15,
+      "int": 7,
+      "wis": 12,
+      "cha": 14,
+      "senses": [
+        "darkvision 30 ft."
+      ],
+      "passive": 11,
+      "languages": [
+        "quickly learns commands in any language"
+      ],
+      "cr": "1/4",
+      "trait": [
+        {
+          "name": "Keen Perceptions",
+          "entries": [
+            "The thuman has advantage on Wisdom (Perception) checks that rely on smell, hearing, or sight."
+          ]
+        },
+        {
+          "name": "Loyal Protector",
+          "entries": [
+            "The thuman has advantage on attack rolls against a creature if the creature that the thuman has pledged service to is within 5 feet."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The thuman can make two bite attacks."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}4 ({@damage 1d6 + 1}) piercing damage."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Keen Senses"
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "X"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A thuman looks much like a large hound, although it has a face that is almost human. Its tough, leathery flesh is covered in short hair except for a longer tuft at the top of its head that resembles a crest.",
+              {
+                "type": "entries",
+                "name": "In Service.",
+                "entries": [
+                  "Thumans are intelligent and affable companions, and rarely the masters of their own affairs, preferring instead to serve others, which they do loyally. They don’t speak, but they understand language well and can be trained to follow a vast number of commands. Thumans are almost never encountered in the wild; they actively seek the company of humans. The PCs likely encounter a thuman at the side of its master, usually someone with some previous experience exploring the legacy of the Ancients, or another creature that itself stepped out of an Ancients’ cache."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "There is an unwritten code among thuman masters to treat their companions extremely well-more like a friend or ally than a pet. The loss of a thuman companion is like the loss of a close family member."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_240_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_240_Image_0002.png"
+    },
+    {
+      "name": "Travonis Ul",
+      "source": "AotA",
+      "page": 239,
+      "size": "H",
+      "type": "aberration",
+      "alignment": [
+        "N",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 142,
+        "formula": "15d12 + 45"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 20,
+      "dex": 15,
+      "con": 19,
+      "int": 15,
+      "wis": 10,
+      "cha": 16,
+      "senses": [
+        "truesight 120 ft."
+      ],
+      "passive": 18,
+      "resist": [
+        "acid",
+        "cold",
+        "fire",
+        "lightning",
+        "thunder"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "poisoned"
+      ],
+      "languages": [
+        "understands most languages but can't speak"
+      ],
+      "cr": "10",
+      "trait": [
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The travonis ul has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magic Weapons",
+          "entries": [
+            "The travonis ul's weapon attacks are magical."
+          ]
+        },
+        {
+          "name": "Regeneration",
+          "entries": [
+            "The travonis ul regains 10 hit points at the start of its turn if it has at least 1 hit point."
+          ]
+        },
+        {
+          "name": "Tendril Strider",
+          "entries": [
+            "The travonis ul's movement is unaffected by difficult terrain."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The travonis ul makes three attacks: one with its bite and two with its tendrils. If the travonis ul is grappling a creature, it can use smother once."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}9 ({@damage 1d8 + 5}) piercing damage plus 7 ({@damage 2d6}) psychic damage."
+          ]
+        },
+        {
+          "name": "Tendril",
+          "entries": [
+            "{@atk mw} {@hit 9} to hit, reach 20 ft., one target. {@h}12 ({@damage 2d6 + 5}) slashing damage plus 7 ({@damage 2d6}) psychic damage. The target is {@condition grappled} (escape {@dc 19}) if it is a Large or smaller creature and the travonis ul doesn't have two other creatures {@condition grappled}."
+          ]
+        },
+        {
+          "name": "Smother",
+          "entries": [
+            "The travonis ul bites and tendril-batters the {@condition grappled} creature, having advantage on attack rolls to do so. Each hit deals an additional 4 ({@damage 1d6}) psychic damage."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Magic Resistance",
+        "Magic Weapons",
+        "Regeneration"
+      ],
+      "senseTags": [
+        "U"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "CS"
+      ],
+      "damageTags": [
+        "P",
+        "S",
+        "Y"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "conditionInflict": [
+        "grappled"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A writhing mass of tendrils 15 feet across and 12 feet high, a travonis ul is a creature from elsewhere that hunts for organic material to consume. Three to five tendrils are particularly long, with bulbous yellow eyes at approximately their midpoint. One broad tendril has a mouth with several mandibles. In addition to the damage a bite or bludgeoning tendril bash deals, the touch of a travonis ul causes great pain and disrupts nervous systems.",
+              {
+                "type": "entries",
+                "name": "Ancients Outsider.",
+                "entries": [
+                  "A travonis ul is an intelligent creature, but it’s utterly alien to almost everything, even to entities related to the Ancients. It doesn’t seem to speak, read, or use tools of any kind, but it clearly understands and respects the numenera. Is it from another plane? Another time? Another world? When it comes to the travonis ul, such questions may not have meaning."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Unearthly Hunger.",
+                "entries": [
+                  "A travonis ul looks upon all other creatures as food or enemies (or both). Travonis ul are some of the most dangerous predators to be found among the Ancients’ ruins, or in neighboring lands. The alien creatures eat constantly, so when one moves into an area, it quickly depletes the region of flora and fauna. Intelligent inhabitants usually organize resistance or just flee."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_241_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_241_Image_0002.png"
+    },
+    {
+      "name": "Varakith",
+      "source": "AotA",
+      "page": 0,
+      "size": "L",
+      "type": "monstrosity",
+      "alignment": [
+        "L",
+        "E"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 114,
+        "formula": "12d10 + 48"
+      },
+      "speed": {
+        "walk": 30,
+        "burrow": 30
+      },
+      "str": 18,
+      "dex": 14,
+      "con": 18,
+      "int": 11,
+      "wis": 10,
+      "cha": 8,
+      "senses": [
+        "tremorsense 120 ft."
+      ],
+      "passive": 10,
+      "languages": [
+        "Varakith"
+      ],
+      "cr": "5",
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The varakith makes two attacks with its spearing legs."
+          ]
+        },
+        {
+          "name": "Spearing Legs",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage. Medium or smaller targets who are hit must also succeed on a {@dc 15} Strength saving throw, or be {@condition grappled} (escape {@dc 15}). A {@condition grappled} creature is attached to the varakith's back with hooks and spikes. Until this grapple ends, the target is {@condition restrained} and takes 7 ({@damage 2d6}) piercing damage each round, while the varakith gains a +1 bonus to AC. Up to three targets can be so {@condition grappled} at one time. Corpses continue to provide a bonus to AC."
+          ]
+        }
+      ],
+      "senseTags": [
+        "T"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "conditionInflict": [
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "A varakith is a vaguely insectlike creature, 10 feet long, with multiple legs that end in tips like spears. It uses these lances to skewer enemies and drain them of blood, after which the creature adds them to its own body to serve as armor. Varakith prefer to dwell alone or in pairs in any temperate or warmer region. They make nests underground.",
+              {
+                "type": "entries",
+                "name": "Singers, Not Mindless Beasts.",
+                "entries": [
+                  "The strange noises the varakith make are actually songs and have meaning. Varakith \"speak\" (or rather, \"sing\") by rubbing two of their legs together, which produces a trilling sound. The song that one sage translated went as follows: We fight and crush Gnash and drink The foe at our heels will be our bread The foe at our heels feeds victories yet to come Stronger today, stronger tomorrow We fight We crush We gnash"
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Coontempuous",
+                "entries": [
+                  "Varakith have a dark and bloodthirsty spirit with little respect for others. However, a creature that proves itself in combat might be considered worth speaking to if communication can be established. Varakith see the world as one big gladiatorial arena in which they must constantly prove themselves. Even a respected combatant is still a foe to be overcome eventually-long-term alliance is not possible. However, varakith are not particularly devious or duplicitous about their mindset. They make their feelings known."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Subterranean Foes.",
+                "entries": [
+                  "Varakith are excellent foes for PCs exploring subterranean areas, and having these monstrous things turn out to be fairly intelligent is a nice twist. Consider a scenario in which a young man hires the PCs to find his brother who disappeared while exploring a cave in the hills. Only after long searches do the characters discover that the brother’s corpse now adorns the back of a vicious varakith."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Varakith only appear after one or more Ancients’ caches open. Once loosed in the world, they likely war against subterranean communities they find in the sunless deeps."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_144_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_144_Image_0002.png"
+    },
+    {
+      "name": "Xi-Drake",
+      "source": "AotA",
+      "page": 241,
+      "size": "H",
+      "type": "monstrosity",
+      "alignment": [
+        "N",
+        "G"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 85,
+        "formula": "9d12 + 27"
+      },
+      "speed": {
+        "walk": 30,
+        "fly": 120
+      },
+      "str": 20,
+      "dex": 18,
+      "con": 17,
+      "int": 12,
+      "wis": 18,
+      "cha": 14,
+      "senses": [
+        "darkvision 120 ft."
+      ],
+      "passive": 14,
+      "languages": [
+        "telepathy 120 ft. (only to receive thoughts, not to send)"
+      ],
+      "cr": "5",
+      "trait": [
+        {
+          "name": "Flyby",
+          "entries": [
+            "The xi-drake doesn't provoke an opportunity attack when it ends its movement out of an enemy's reach."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The xi-drake has advantage on saving throws against spells and other magical effects."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The xi-drake makes one bite and one tail slam attack."
+          ]
+        },
+        {
+          "name": "Bite",
+          "entries": [
+            "{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}21 ({@damage 3d10 + 5}) piercing damage, and the target is {@condition grappled}"
+          ]
+        },
+        {
+          "name": "(escape {@dc 16})",
+          "entries": [
+            "Until this grapple ends, the target is {@condition restrained}, and the xi-drake can't bite another target."
+          ]
+        },
+        {
+          "name": "Tail Slam",
+          "entries": [
+            "{@atk mw} {@hit 8} to hit, reach 10 ft., one target. {@h}14 ({@damage 2d8 + 5}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 16} Strength saving throw or be knocked {@condition prone}."
+          ]
+        },
+        {
+          "name": "Read Thoughts",
+          "entries": [
+            "The xi-drake telepathically reads the surface thoughts of one creature within 120 feet that it can see as a bonus action. While the target is in range, the xi-drake can continue reading its thoughts, even if taking normal actions.",
+            "While reading the target's mind, the xi-drake has advantage on Wisdom (Insight) and Charisma (Persuasion) checks against the target. A creature aware of the mind-reading who doesn't want their mind to be read must succeed on a {@dc 17} Wisdom saving throw, which confers a day's immunity if successful."
+          ]
+        }
+      ],
+      "reaction": [
+        {
+          "name": "Anticipate Attack (5-6)",
+          "entries": [
+            "The xi-drake anticipates one melee attack that would hit it and negates it. To do so, the xi-drake must be reading the target's thoughts."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Flyby",
+        "Magic Resistance"
+      ],
+      "senseTags": [
+        "SD"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "TP"
+      ],
+      "damageTags": [
+        "B",
+        "P"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "conditionInflict": [
+        "grappled",
+        "prone",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Xi-drakes sometimes darken the skies over Ancients’ caches. Their massive size, white skin, reptile-like form with broad wings, and long tail means they are sometimes confused with different creatures entirely.",
+              {
+                "type": "entries",
+                "name": "Mind Readers.",
+                "entries": [
+                  "Xi-drakes have keen senses, but more impressively, they can read the mind of any intelligent living creature within 120 feet and thus are almost impossible to deceive."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Sociable, Amenable to Pacts.",
+                "entries": [
+                  "Though telepathic, they cannot speak (telepathically or otherwise). However, their ability to read minds allows a sort of communication. They are not so much tamed or trained as they are befriended. Sometimes they enter into pacts with individuals (or groups), and serve as mounts. Once a xi-drake is bound to a rider/ companion, the two work in concert until death (usually the death of the rider, since xidrakes live for hundreds of years)."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Xi-drakes, decanted from stasis pods by explorers, seem willing to interact with whatever creatures they encounter."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_243_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_243_Image_0002.png"
+    },
+    {
+      "name": "Yellow Swarm",
+      "source": "AotA",
+      "page": 242,
+      "size": "M",
+      "type": {
+        "type": "beast",
+        "swarmSize": "T"
+      },
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 65,
+        "formula": "10d8 + 20"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 20,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 17,
+      "dex": 15,
+      "con": 15,
+      "int": 2,
+      "wis": 11,
+      "cha": 13,
+      "senses": [
+        "blindsight 60 ft."
+      ],
+      "passive": 10,
+      "resist": [
+        "bludgeoning",
+        "piercing",
+        "slashing"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "frightened",
+        "grappled",
+        "paralyzed",
+        "petrified",
+        "prone",
+        "restrained",
+        "stunned"
+      ],
+      "trait": [
+        {
+          "name": "Swarm",
+          "entries": [
+            "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The yellow swarm makes three bites attacks."
+          ]
+        },
+        {
+          "name": "Bites",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 0 ft., one target in the swarm's space. {@h}17 ({@damage 4d6 + 3}) piercing damage, or 10 ({@damage 2d6 + 3}) piercing damage if the swarm has half of its hit points or fewer."
+          ]
+        },
+        {
+          "name": "Reality Phase {@recharge 4}",
+          "entries": [
+            "The yellow swarm fades into a different reality not normally accessible by other creatures for one round, rendering attacks against it moot. Before or after reality phase, the yellow swarm can make one bites attack."
+          ]
+        }
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW"
+      ],
+      "cr": "4",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "Yellow swarms are groups of insect-like creatures. They must stay in close proximity to one another, or they lose their ability to remain on this plane of existence. They look like a small cloud of yellow locusts until you get close enough to see that they are transparent and oddly configured, with asymmetrical bodies that have seven legs and five wings.",
+              {
+                "type": "entries",
+                "name": "Hunger for Brain Fluids.",
+                "entries": [
+                  "Yellow swarms feed on various chemicals in the brains and spines of living creatures. Defending against this hunger is tough because a yellow swarm is always fading in and out of reality. Yellow swarms often linger near interdimensional gates or other access points, so the presence of a swarm is a good indicator that a gate is nearby."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_244_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_244_Image_0002.png"
+    },
+    {
+      "name": "Yovok",
+      "source": "AotA",
+      "page": 243,
+      "size": "S",
+      "type": {
+        "type": "humanoid",
+        "tags": [
+          "yovok"
+        ]
+      },
+      "alignment": [
+        "C",
+        "N"
+      ],
+      "ac": [
+        {
+          "ac": 14,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 14,
+        "formula": "4d6 + 4"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 10,
+      "dex": 16,
+      "con": 13,
+      "int": 9,
+      "wis": 10,
+      "cha": 10,
+      "skill": {
+        "athletics": "+4"
+      },
+      "senses": [
+        "darkvision 60 ft."
+      ],
+      "passive": 10,
+      "languages": [
+        "Yovok",
+        "some understand Common"
+      ],
+      "cr": "1/4",
+      "action": [
+        {
+          "name": "Spear",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage."
+          ]
+        },
+        {
+          "name": "Barb Spit {@recharge 5}",
+          "entries": [
+            "{@atk rw} {@hit 5} to hit, range 40 ft., one target. {@h}6 ({@damage 1d6 + 3}) piercing damage, and target must succeed on a {@dc 13} Constitution saving throw or become {@condition paralyzed} for the next four rounds."
+          ]
+        }
+      ],
+      "senseTags": [
+        "D"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "P"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "conditionInflict": [
+        "paralyzed"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              "The horrid yovoki are short, squat, corrupt humanoids with jaundiced skin draped loosely over their flabby, hairless bodies. They hunt and kill for pleasure, although they happily eat whatever they kill as well. In fact, they eat constantly and seem able to digest almost anything. Yovoki wander in small groups of three to six in the mountains and hills.",
+              {
+                "type": "entries",
+                "name": "Savage Humanoid Effigies.",
+                "entries": [
+                  "Yovoki are too disordered to have a strict group hierarchy. Instead, they all just yell and snort and squeal until one of them gets their way. There are two yovoki genders, but sometimes even they cannot tell the difference between their males and females. They kill for pleasure, food, and as displays of strength."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Gutter Schemers.",
+                "entries": [
+                  "Fast-talking characters might be able to reason with yovoki, but doing so is difficult due to their bloodlust. It might be easier for the PCs to intimidate or frighten them into compliance. Despite their corrupt and savage nature, some are smart enough to use numenera devices or hatch simple plots to get what they want-poisoning wells, kidnapping important people, and so on."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Like killisti, yovoki are apparently humans mutated by numenera devices, possibly purposefully, though to what end and by what is unknown."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "Each yovok has a spear, club, or other melee weapon. A group of yovoki has at least one cypher among them."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_245_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_245_Image_0002.png"
+    },
+    {
+      "name": "Zhev",
+      "source": "AotA",
+      "page": 244,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "L",
+        "G"
+      ],
+      "ac": [
+        {
+          "ac": 20,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 60,
+        "formula": "8d8 + 24"
+      },
+      "speed": {
+        "walk": 0,
+        "fly": {
+          "number": 60,
+          "condition": "(hover)"
+        },
+        "canHover": true
+      },
+      "str": 17,
+      "dex": 12,
+      "con": 16,
+      "int": 10,
+      "wis": 10,
+      "cha": 10,
+      "skill": {
+        "perception": "+4"
+      },
+      "senses": [
+        "blindsight 120 ft. (blind beyond this radius)"
+      ],
+      "passive": 14,
+      "resist": [
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical attacks not made with adamantine weapons"
+        }
+      ],
+      "immune": [
+        "force",
+        "necrotic",
+        "poison"
+      ],
+      "conditionImmune": [
+        "blinded",
+        "charmed",
+        "deafened",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned",
+        "stunned"
+      ],
+      "languages": [
+        "Zhev",
+        "some understand Common"
+      ],
+      "cr": "4",
+      "trait": [
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The Zhev has advantage on saving throws against spells and other magical effects."
+          ]
+        },
+        {
+          "name": "Magic Weapons",
+          "entries": [
+            "The Zhev's weapon attacks are treated as if magical."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Multiattack",
+          "entries": [
+            "The Zhev makes three tentacular arm attacks."
+          ]
+        },
+        {
+          "name": "Tentacular Arm",
+          "entries": [
+            "{@atk mw} {@hit 6} to hit, reach 10 ft., one target. {@h}7 ({@damage 1d8 + 3}) bludgeoning damage."
+          ]
+        },
+        {
+          "name": "Net",
+          "entries": [
+            "{@atk rw} {@hit 3} to hit, range 5/15 ft., one Large or smaller creature. {@h}The target is {@condition restrained}. A creature can use its action to make a {@dc 15} Strength check to free itself or another creature in a net, ending the effect on a success.",
+            "Dealing 5 slashing damage to the net (AC 15) frees the target without harming it and destroys the net."
+          ]
+        },
+        {
+          "name": "Incapacitating Gas {@recharge 5}",
+          "entries": [
+            "The Zhev fires a canister to a point within 120 feet that it can see, which then detonates.",
+            "Each creature in a 20-foot-radius sphere centered on that point must succeed on a {@dc 15} Constitution saving throw or be {@condition incapacitated} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+          ]
+        }
+      ],
+      "traitTags": [
+        "Magic Resistance",
+        "Magic Weapons"
+      ],
+      "senseTags": [
+        "B"
+      ],
+      "actionTags": [
+        "Multiattack"
+      ],
+      "languageTags": [
+        "C"
+      ],
+      "damageTags": [
+        "B"
+      ],
+      "miscTags": [
+        "AOE",
+        "MW",
+        "RCH",
+        "RW",
+        "THW"
+      ],
+      "conditionInflict": [
+        "incapacitated",
+        "restrained"
+      ],
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  "Zhev seem inclined to prevent infractions of the law and act to preserve order, keep the peace, and protect the lives of innocents."
+                ]
+              },
+              "Zhev are cylinders 6 feet high and 3 feet in diameter, and typically hover 3 feet off the ground. Their three triangular eyes appear to be organic. The eyes usually stay together in a larger triangle formation, moving inside the cylinder, peering through a slit near the top that goes all the way around. The eyes can also separate, each looking in a different direction, but they do this rarely.",
+              {
+                "type": "entries",
+                "name": "Biomechanical and Resolute.",
+                "entries": [
+                  "Although the Zhev are essentially constructs, they have organic interior components as well as mechanical parts. When activated, they either return to whatever Ancients’ command they last received (which likely makes little sense in their new context) or look for new instructions."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Enforcers of Law.",
+                "entries": [
+                  "If a group of Zhev find themselves at loose ends, they may offer their services to a city or other location. If a pact is agreed to, affected Zhev obey the orders given to them by their new hosts. Other people cannot reason or negotiate with the Zhev. They are relentless and merciless, though they first attempt to capture criminals rather than use violent or lethal force. Usually, the Zhev seem inclined to prevent infractions of the law and act to preserve order, keep the peace, and protect the lives of innocents. When forced to choose between options, they always make the choice that saves the most people from the greatest harm. Protecting innocents takes priority over enforcing laws, assuming Zhev in the area even know what local laws might apply."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "PCs who run afoul of the Zhev have likely done something very wrong."
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  "The Zhev usually begin a fight by firing stun gas canisters or nets. If the gas and nets fail, Zhev physically attack."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Salvage.",
+                "entries": [
+                  "The body of a defeated Zhev can be scavenged for a cypher, and sometimes (1 in 1d10) a relic."
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "But how well does their metal hide stand up to an axe? Now that’s a question that wants an answer."
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              },
+              {
+                "type": "inset",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "Why? They seem peaceable enough. Civic-minded, one might say."
+                    ],
+                    "by": "Elmande, elf mage and scholar"
+                  }
+                ]
+              },
+              {
+                "type": "insetReadaloud",
+                "entries": [
+                  {
+                    "type": "quote",
+                    "entries": [
+                      "They’re not natural, is why. Sure, the one we met saved us from that machine demon, thank the Forge. I appreciate that. But you're the one who pointed out what the quotien lore said about these Zhev—theyll always act to ensure a just outcome for the largest number of innocent beings, not matter what. Which means that if they have to kill five folks to save six, then those five had better be right with their gods. And that just isn’t right. Plus, why is it Zhev with a capitol 'Z'?"
+                    ],
+                    "by": "Faim Trubeard, dwarf veteran and prospector"
+                  }
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_247_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_247_Image_0002.png"
+    },
+    {
+      "name": "Basic Automaton, Type One",
+      "source": "AotA",
+      "page": 246,
+      "size": "T",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 11,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 10,
+        "formula": "4d4"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 3,
+      "dex": 10,
+      "con": 10,
+      "int": 8,
+      "wis": 8,
+      "cha": 5,
+      "passive": 9,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "trait": [
+        {
+          "name": "Skill Proficiency",
+          "entries": [
+            "The Automaton may use any one skill with profficiency +1"
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Melee Attack",
+          "entries": [
+            "Melee Weapon Attack:{@hit -2} to hit, reach 5 ft., one target. {@h}1 slashing damage."
+          ]
+        },
+        {
+          "name": "Ranged Attack",
+          "entries": [
+            "{@atk rw} {@hit 2} to hit, range",
+            "30/60 ft., one target. {@h}1 piercing damage."
+          ]
+        }
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "RW"
+      ],
+      "cr": "1/8",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  "The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
+                ]
+              },
+              "The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
+              {
+                "type": "inset",
+                "entries": [
+                  "The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+    },
+    {
+      "name": "Basic Automaton, Type Two",
+      "source": "AotA",
+      "page": 246,
+      "size": "S",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 11,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 35,
+        "formula": "8d6 + 8"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 7,
+      "dex": 13,
+      "con": 13,
+      "int": 10,
+      "wis": 10,
+      "cha": 7,
+      "passive": 10,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "trait": [
+        {
+          "name": "Skill Proficiency",
+          "entries": [
+            "The Automaton may use any one skill with profficiency +2"
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Melee Attack",
+          "entries": [
+            "{@atk mw} {@hit 0} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) slashing damage."
+          ]
+        },
+        {
+          "name": "Ranged Attack",
+          "entries": [
+            "{@atk rw} {@hit 3} to hit, range",
+            "30/60 ft., one target. {@h}3 ({@damage 1d4 + 1}) piercing damage."
+          ]
+        }
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "cr": "1/4",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  "The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
+                ]
+              },
+              "The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
+              {
+                "type": "inset",
+                "entries": [
+                  "The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+    },
+    {
+      "name": "Basic Automaton, Type Three",
+      "source": "AotA",
+      "page": 247,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 13,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 65,
+        "formula": "10d8 + 20"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 15,
+      "dex": 13,
+      "con": 15,
+      "int": 10,
+      "wis": 12,
+      "cha": 7,
+      "save": {
+        "str": "+4"
+      },
+      "passive": 11,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "trait": [
+        {
+          "name": "Skill Proficiency",
+          "entries": [
+            "The Automaton may use any one skill with profficiency +2"
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Melee Attack",
+          "entries": [
+            "{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}9 ({@damage 2d6 + 2}) slashing damage."
+          ]
+        },
+        {
+          "name": "Ranged Attack",
+          "entries": [
+            "{@atk rw} {@hit 3} to hit, range",
+            "30/60 ft., one target. {@h}8 ({@damage 2d6 + 1}) piercing damage."
+          ]
+        }
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "cr": "1/4",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  "The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
+                ]
+              },
+              "The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
+              {
+                "type": "inset",
+                "entries": [
+                  "The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+    },
+    {
+      "name": "Basic Automaton, Type Four",
+      "source": "AotA",
+      "page": 247,
+      "size": "M",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 90,
+        "formula": "12d8 + 36"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 17,
+      "dex": 13,
+      "con": 17,
+      "int": 10,
+      "wis": 12,
+      "cha": 7,
+      "save": {
+        "str": "+5"
+      },
+      "passive": 11,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "trait": [
+        {
+          "name": "Skill Proficiency",
+          "entries": [
+            "The Automaton may use any one skill with profficiency +2"
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Melee Attack",
+          "entries": [
+            "{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}17 ({@damage 4d6 + 3}) slashing damage."
+          ]
+        },
+        {
+          "name": "Ranged Attack",
+          "entries": [
+            "{@atk rw} {@hit 3} to hit, range",
+            "30/60 ft., one target. {@h}15 ({@damage 4d6 + 1}) piercing damage."
+          ]
+        }
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "cr": "4",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  "The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
+                ]
+              },
+              "The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
+              {
+                "type": "inset",
+                "entries": [
+                  "The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+    },
+    {
+      "name": "Basic Automaton, Type Five",
+      "source": "AotA",
+      "page": 248,
+      "size": "L",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 15,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "average": 133,
+        "formula": "14d10 + 56"
+      },
+      "speed": {
+        "walk": 30
+      },
+      "str": 19,
+      "dex": 13,
+      "con": 19,
+      "int": 10,
+      "wis": 12,
+      "cha": 7,
+      "save": {
+        "str": "+7"
+      },
+      "passive": 11,
+      "immune": [
+        "poison"
+      ],
+      "conditionImmune": [
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "paralyzed",
+        "petrified",
+        "poisoned"
+      ],
+      "trait": [
+        {
+          "name": "Skill Proficiency",
+          "entries": [
+            "The Automaton may use any one skill with profficiency +3"
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Melee Attack",
+          "entries": [
+            "{@atk mw} {@hit 7} to hit, reach 5 ft., one target. {@h}32 ({@damage 8d6 + 4}) slashing damage."
+          ]
+        },
+        {
+          "name": "Ranged Attack",
+          "entries": [
+            "{@atk rw} {@hit 4} to hit, range",
+            "30/60 ft., one target. {@h}29 ({@damage 8d6 + 1}) piercing damage."
+          ]
+        }
+      ],
+      "damageTags": [
+        "P",
+        "S"
+      ],
+      "miscTags": [
+        "MW",
+        "RW"
+      ],
+      "cr": "6",
+      "fluff": {
+        "entries": [
+          {
+            "type": "entries",
+            "entries": [
+              {
+                "type": "inset",
+                "entries": [
+                  "The Ancients relied on automatons of every shape and size. However, despite their variety, certain automaton models have the same basic functions, though not always the same form."
+                ]
+              },
+              "The Ancients created many kinds of automatons to take care of repetitive or dangerous tasks. These automatons’ shapes and composition may vary, and the simplest ones have a very limited number of functions. This material provides statistics for various simple automatons that adventurers might encounter during a campaign. These stat blocks can be used to represent almost any kind of uninteresting automaton-servant units that prepare or serve food, crafting units that build basic structures out of stone or wood, scouts that patrol an area, guardians that protect a creature or location, and so on. The GM can customize them by adjusting size, stats, specifying what form its attacks take (claws, slams, and so on), adding manufactured weapons (swords, rays, or even cyphers or relics), different movement modes, skill bonuses, or even a special ability. These changes should be limited so the GM doesn’t have to adjust the automaton’s challenge rating. For example, the basic automaton’s listed melee attack method is just called \"melee attack\"; it doesn’t matter if that’s a claw, drill, or blade, and the GM can use the listed attack stats for whatever weapon they decide the automaton is using. Depending on the automaton’s role, it may not have more than one attack type (a chef automaton might attack with a built-in chopping knife but not have any way to make ranged attacks). The following creature stat listings cover the five most common types of basic automatons.",
+              {
+                "type": "inset",
+                "entries": [
+                  "The purpose of these stat blocks is to provide easy-to-use automatons for the various numenera, creatures, and adventures that need them (the equivalent of having stat blocks for generic NPCs). Customizing their stats too much isn’t worth the effort."
+                ]
+              }
+            ]
+          }
+        ],
+        "images": [
+          {
+            "type": "image",
+            "href": {
+              "type": "external",
+              "url": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+            }
+          }
+        ]
+      },
+      "img": "https://raw.githubusercontent.com/rubzanatta/arcana5etools/master/AotAImages/AotABook_Page_249_Image_0002.png"
+    }
+  ]
 }


### PR DESCRIPTION
Putting in place the image urls in the fluff. This seems to take care of base image import into VTTs, but does not account for token borders. What we will need to do, most likely, is manually create them with some separate tokenizer app. If we do that, I can make a second run-through script to assign those as well.

As much as I would have liked it, I can't see how the token creation could be automated--there's usually some modification (movement of the token "ring", zooming in/out, etc) that needs be done. 